### PR TITLE
OPAM packaging and Travis integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ src/quickChickToolLexer.ml
 src/quickChickToolParser.ml
 src/quickChickToolParser.mli
 src/quickChickToolParser.output
+src/quickChickTool

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -8,7 +8,7 @@ opam repo add coq-released https://coq.inria.fr/opam/released
 case $MODE in
   quickchick-plugin)
     opam pin add quickchick-plugin . --yes --verbose
-    make -j4 tests
+    make tests
     ;;
   quickchick-tool)
     opam pin add quickchick-tool . --yes --verbose

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -8,6 +8,7 @@ opam repo add coq-released https://coq.inria.fr/opam/released
 case $MODE in
   quickchick-plugin)
     opam pin add quickchick-plugin . --yes --verbose
+    make -j4 tests
     ;;
   quickchick-tool)
     opam pin add quickchick-tool . --yes --verbose

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,0 +1,15 @@
+set -ev
+
+opam init --yes --no-setup
+eval $(opam config env)
+
+opam repo add coq-released https://coq.inria.fr/opam/released
+
+case $MODE in
+  quickchick-plugin)
+    opam pin add quickchick-plugin . --yes --verbose
+    ;;
+  quickchick-tool)
+    opam pin add quickchick-tool . --yes --verbose
+    ;;
+esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - aspcud
 env:
   matrix:
-    - MODE=quickchick-plugin OPAMBUILDTEST=1
+    - MODE=quickchick-plugin
     - MODE=quickchick-tool
 script: bash -ex .travis-ci.sh
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - ocaml
       - opam
       - aspcud
+      - time
 env:
   matrix:
     - MODE=quickchick-plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+addons:
+  apt:
+    sources:
+      - avsm
+    packages:
+      - ocaml
+      - opam
+      - aspcud
+env:
+  matrix:
+    - MODE=quickchick-plugin OPAMBUILDTEST=1
+    - MODE=quickchick-tool
+script: bash -ex .travis-ci.sh
+sudo: false
+notifications:
+  email: false

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ install: plugin Makefile.coq src/quickChickLib.cmx src/quickChickLib.o quickChic
 	 cp src/quickChickLib.o $(COQLIB)/user-contrib/QuickChick
 	 cp src/quickChickTool $(shell echo $(PATH) | tr ':' "\n" | grep opam)/quickChick
 
+install-plugin:
+	$(MAKE) -f Makefile.coq install
+
 quickChickTool: 
 	ocamllex  src/quickChickToolLexer.mll
 #	menhir --explain src/quickChickToolParser.mly

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: plugin install clean
+.PHONY: plugin install install-plugin clean
 
 # Here is a hack to make $(eval $(shell work
 # (copied from coq_makefile generated stuff):
@@ -38,10 +38,9 @@ quickChickTool:
 	ocamlc -o src/quickChickTool str.cma src/quickChickToolTypes.cmo src/quickChickToolLexer.cmo src/quickChickToolParser.cmo src/quickChickTool.cmo
 
 tests:
-	coqc examples/Tests.v
-	cd examples/RedBlack; make clean && make
-	cd examples/stlc; make clean && make
-	cd examples/ifc-basic; make clean && make
+	+$(MAKE) -C examples/RedBlack clean all
+	+$(MAKE) -C examples/stlc clean all
+	+$(MAKE) -C examples/ifc-basic clean all
 
 Makefile.coq: Make
 	coq_makefile -f Make -o Makefile.coq

--- a/quickchick-plugin.install
+++ b/quickchick-plugin.install
@@ -1,0 +1,2 @@
+lib: ["src/quickChickLib.cmx" {"../coq/user-contrib/QuickChick/quickChickLib.cmx"}
+      "src/quickChickLib.o" {"../coq/user-contrib/QuickChick/quickChickLib.o"}]

--- a/quickchick-plugin.opam
+++ b/quickchick-plugin.opam
@@ -10,6 +10,7 @@ license: "BSD"
 build: [
   [ make "-j%{jobs}%" "plugin" ]
 ]
+build-test: [make "tests"]
 install: [ make "install-plugin" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/QuickChick'" ]
 depends: [

--- a/quickchick-plugin.opam
+++ b/quickchick-plugin.opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/QuickChick/QuickChick"
+dev-repo: "https://github.com/QuickChick/QuickChick.git"
+bug-reports: "https://github.com/QuickChick/QuickChick/issues"
+license: "BSD"
+
+build: [
+  [ make "-j%{jobs}%" "plugin" ]
+]
+install: [ make "install-plugin" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/QuickChick'" ]
+depends: [
+  "coq" {>= "8.6" & < "8.7~"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.7~"}
+]
+
+authors: [
+  "Catalin Hritcu <>"
+  "Leonidas Lampropoulos <>"
+  "Zoe Paraskevopoulou <>"
+  "Maxime Denes <>"
+  "Arthur Azevedo de Amorim <>"
+  "Antal Spector-Zabusky <>"
+  "Benjamin Pierce <>"
+]

--- a/quickchick-plugin.opam
+++ b/quickchick-plugin.opam
@@ -7,10 +7,7 @@ dev-repo: "https://github.com/QuickChick/QuickChick.git"
 bug-reports: "https://github.com/QuickChick/QuickChick/issues"
 license: "BSD"
 
-build: [
-  [ make "-j%{jobs}%" "plugin" ]
-]
-build-test: [make "tests"]
+build: [ make "-j%{jobs}%" "plugin" ]
 install: [ make "install-plugin" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/QuickChick'" ]
 depends: [

--- a/quickchick-plugin.opam
+++ b/quickchick-plugin.opam
@@ -5,7 +5,7 @@ maintainer: "palmskog@gmail.com"
 homepage: "https://github.com/QuickChick/QuickChick"
 dev-repo: "https://github.com/QuickChick/QuickChick.git"
 bug-reports: "https://github.com/QuickChick/QuickChick/issues"
-license: "BSD"
+license: "MIT"
 
 build: [ make "-j%{jobs}%" "plugin" ]
 install: [ make "install-plugin" ]

--- a/quickchick-plugin.opam
+++ b/quickchick-plugin.opam
@@ -14,6 +14,7 @@ depends: [
   "coq" {>= "8.6" & < "8.7~"}
   "coq-mathcomp-ssreflect" {>= "1.6" & < "1.7~"}
 ]
+available: [ ocaml-version >= "4.02.3" ]
 
 authors: [
   "Catalin Hritcu <>"

--- a/quickchick-tool.install
+++ b/quickchick-tool.install
@@ -1,0 +1,1 @@
+bin: ["src/quickChickTool" {"quickChick"}]

--- a/quickchick-tool.opam
+++ b/quickchick-tool.opam
@@ -5,7 +5,7 @@ maintainer: "palmskog@gmail.com"
 homepage: "https://github.com/QuickChick/QuickChick"
 dev-repo: "https://github.com/QuickChick/QuickChick.git"
 bug-reports: "https://github.com/QuickChick/QuickChick/issues"
-license: "BSD"
+license: "MIT"
 
 build: [
   [ make "quickChickTool" ]

--- a/quickchick-tool.opam
+++ b/quickchick-tool.opam
@@ -7,11 +7,9 @@ dev-repo: "https://github.com/QuickChick/QuickChick.git"
 bug-reports: "https://github.com/QuickChick/QuickChick/issues"
 license: "MIT"
 
-build: [
-  [ make "quickChickTool" ]
-]
-available: [ ocaml-version >= "4.02.3" ]
+build: [ make "quickChickTool" ]
 depends: [ ]
+available: [ ocaml-version >= "4.02.3" ]
 
 authors: [
   "Catalin Hritcu <>"

--- a/quickchick-tool.opam
+++ b/quickchick-tool.opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/QuickChick/QuickChick"
+dev-repo: "https://github.com/QuickChick/QuickChick.git"
+bug-reports: "https://github.com/QuickChick/QuickChick/issues"
+license: "BSD"
+
+build: [
+  [ make "quickChickTool" ]
+]
+available: [ ocaml-version >= "4.02.3" ]
+depends: [ ]
+
+authors: [
+  "Catalin Hritcu <>"
+  "Leonidas Lampropoulos <>"
+  "Zoe Paraskevopoulou <>"
+  "Maxime Denes <>"
+  "Arthur Azevedo de Amorim <>"
+  "Antal Spector-Zabusky <>"
+  "Benjamin Pierce <>"
+]


### PR DESCRIPTION
I'm interested in using QuickChick in one of my Coq 8.6 projects. The `trunk` branch seemed to be the most active, but the current Makefile there is very ad-hoc w.r.t. building and installation. I created two OPAM packages, one for the plugin and one for the mutation tool, that can be used to install/update/remove things as required in an OPAM-based setting like mine. To demonstrate that they work as expected, I activated Travis in my fork and added Travis scripts.