### PR TITLE
Remove dependency on NPeano.

### DIFF
--- a/src/Classes.v
+++ b/src/Classes.v
@@ -1,8 +1,7 @@
 Set Warnings "-extraction-opaque-accessed,-extraction".
 Set Warnings "-notation-overridden,-parsing".
 
-Require Import Coq.Numbers.Natural.Peano.NPeano
-        Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms.
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrbool ssrnat.
 Require Import Sets GenLow Tactics.

--- a/src/Instances.v
+++ b/src/Instances.v
@@ -1,7 +1,6 @@
 Set Warnings "-extraction-opaque-accessed,-extraction".
 Set Warnings "-notation-overridden,-parsing".
 
-Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrbool ssrnat.
 Require Import GenLow GenHigh Sets.

--- a/src/Test.v
+++ b/src/Test.v
@@ -5,17 +5,12 @@ Require Import Omega.
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrnat ssrbool eqtype div.
 
-Require Import Show RoseTrees.
-Require Import RandomQC.
-Require Import GenLow GenHigh SemChecker.
-Require Import Checker.
-Require Import State.
-Require Import Classes.
+From QuickChick Require Import RoseTrees RandomQC GenLow GenHigh SemChecker.
+From QuickChick Require Import Show Checker State Classes.
 
 Require Import Coq.Strings.String.
 Require Import Coq.Strings.Ascii.
 Require Import Coq.Strings.String.
-Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import List.
 
 Require Import Recdef.

--- a/src/classes_old.v
+++ b/src/classes_old.v
@@ -1,4 +1,3 @@
-Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrbool ssrnat.
 Require Import GenLow GenHigh Sets.

--- a/src/coqLib.ml
+++ b/src/coqLib.ml
@@ -134,10 +134,10 @@ let leq_addl n1 n2 =
 let gProp = gInject "prop"
 
 let succ_neq_zero x =
-  gApp ~explicit:true (gInject "NPeano.Nat.neq_succ_0") [x]
+  gApp ~explicit:true (gInject "PeanoNat.Nat.neq_succ_0") [x]
 
 let succ_neq_zero_app x h =
-  gApp ~explicit:true (gInject "NPeano.Nat.neq_succ_0") [x; h]
+  gApp ~explicit:true (gInject "PeanoNat.Nat.neq_succ_0") [x; h]
 
 let isSome x =
   gApp (gInject "isSome") [x]


### PR DESCRIPTION
This file (from Coq stdlib) is deprecated, and it turns out that using
it triggers an extraction bug (the .ml file produced by Separate
Extraction does not match the .mli file).

We should still try to minimize and report the extraction bug, but from
QuickChick's point of view, this is an easy fix.