### PR TITLE
Fix compilation of quickchick with OCaml's -strict-sequence on.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dsss17/terse
 *.cmx
 *.cmxa
 *.cmxs
+*.cmt
+*.cmti
 *.hi
 *.o
 *.v.d
@@ -17,6 +19,7 @@ dsss17/terse
 *.vo
 *.aux
 *.a
+*.annot
 .coq-native
 \#*
 *~

--- a/src/quickChick.ml4
+++ b/src/quickChick.ml4
@@ -150,7 +150,7 @@ let define_and_run c =
   Sys.remove mlif;
   (* TODO: Maxime, thoughts? *)
   (** LEO: However, sometimes the inferred types are too abstract. So we touch the .mli to close the weak types. **)
-  Sys.command ("touch " ^ mlif);
+  let _exit_code = Sys.command ("touch " ^ mlif) in
   (*
   Printf.printf "Extracted ML file: %s\n" mlf;
   Printf.printf "Compile command: %s\n" (comp_ml_cmd mlf execn);

--- a/src/tactic_quickchick.ml4
+++ b/src/tactic_quickchick.ml4
@@ -18,7 +18,7 @@ let quickchick_goal =
 
     (* Admit a constant with that type *)
     let tmpid = QuickChick.fresh_name "temporary_constant" in
-    Vernacentries.interp (CAst.make @@ Vernacexpr.VernacExpr ([],
+    let _interp_st = Vernacentries.interp (CAst.make @@ Vernacexpr.VernacExpr ([],
       (* TODO: NoDischarge or DoDischarge? *)
       Vernacexpr.VernacAssumption ((NoDischarge, Decl_kinds.Conjectural),
                         NoInline,
@@ -31,8 +31,7 @@ let quickchick_goal =
                            )
                           )
                         ]
-                       )));
-
+                       ))) in
 
     let s = QuickChick.runTest
             (CAst.make @@ CApp((None,QuickChick.quickCheck), [CAst.make @@ CRef (Libnames.qualid_of_ident tmpid,None), None])) in


### PR DESCRIPTION
This should be compatible with any Coq/OCaml combination. Soon, Coq
will use this stricter flag by default.