### PR TITLE
Adapt to https://github.com/coq/coq/pull/8063

### DIFF
--- a/src/Show.v
+++ b/src/Show.v
@@ -181,18 +181,18 @@ Instance showType : Show Type :=
 
 Instance showEx {A} `{_ : Show A} P : Show ({x : A | P x}) :=
   {|
-    show ex := let '(exist _ x _) := ex in show x 
+    show ex := let '(exist _ x _) := ex in show x
   |}.
 
 Require Import Ascii.
 Definition nl : string := String (ascii_of_nat 10) EmptyString.
 
 Definition smart_paren (s : string) : string :=
-  let fix aux s (b : bool) := 
-      match s with 
+  let fix aux s (b : bool) :=
+      match s with
         | EmptyString => (if b then ")" else "", b)
-        | String a s => 
-          let (s', b) := aux s (orb b (nat_of_ascii a =? 32)) in
+        | String a s =>
+          let (s', b) := aux s (orb b (nat_of_ascii a =? 32)%nat) in
           (String a s', b)
       end in
   let (s', b) := aux s false in
@@ -215,8 +215,8 @@ Instance repr_option {A} `{_ : ReprSubset A} : ReprSubset (option A) :=
   {| representatives := None :: map Some representatives |}.
 
 Instance repr_list {A} `{_ : ReprSubset A} : ReprSubset (list A) :=
-  {| representatives := 
-       [] :: map (fun x => [x]) representatives 
+  {| representatives :=
+       [] :: map (fun x => [x]) representatives
           ++ flat_map (fun x : A =>
                          map (fun y : A => [x;y]) representatives
                       ) representatives
@@ -225,19 +225,19 @@ Instance repr_list {A} `{_ : ReprSubset A} : ReprSubset (list A) :=
 Instance repr_prod {A B} `{_ : ReprSubset A} `{_ : ReprSubset B} :
   ReprSubset (A * B) :=
   {| representatives :=
-       flat_map (fun x : A => 
+       flat_map (fun x : A =>
                    map (fun y : B => (x,y)) representatives
-                ) representatives 
+                ) representatives
   |}.
 
 Fixpoint prepend {A : Type} (a : A) (l : list A) :=
-  match l with 
+  match l with
     | [] => []
     | h::t => a :: h :: prepend a t
   end.
 
 Definition intersperse {A : Type} (a : A) (l : list A) :=
-  match l with 
+  match l with
     | [] => []
     | h::t => h :: prepend a t
   end.
@@ -247,11 +247,11 @@ Definition string_concat (l : list string) : string :=
 
 Instance show_fun {A B} `{_ : Show A} `{_ : ReprSubset A}
          `{_ : Show B} : Show (A -> B) :=
-  {| show f := 
-       "{ " ++ string_concat (intersperse " , " 
+  {| show f :=
+       "{ " ++ string_concat (intersperse " , "
                             (map (fun x => show x ++ " |-> " ++ show (f x))
                                  (@representatives A _)))
            ++ " }"
-  |}.            
+  |}.
 
 End ShowFunctions.


### PR DESCRIPTION
There is now a `=?` notation in `string_scope`, so we need to delimit some other scopes explicitly.

Although this does need to be merged to be compatible (and it's backwards compatible), I'm not sure if there are other things that need to be adapted, because I can't actually test all of QuickChick, because it doesn't seem to build with Coq master?  I get
```
$  make COQBIN="$HOME/Documents/repos/coq-string-eqb/bin/" -j100
make -f Makefile.coq
make[1]: Entering directory '/home/jgross/Documents/repos/QuickChick'
ocamlbuild -use-ocamlfind -pkg coq.lib -cflags -rectypes -tag thread quickChickTool/quickChickTool.byte
+ ocamlfind ocamldep -package coq.lib -modules quickChickTool/quickChickTool.ml > quickChickTool/quickChickTool.ml.depends
ocamlfind: Package `coq.lib' not found
Command exited with code 2.
Compilation unsuccessful after building 1 target (0 cached) in 00:00:00.
Makefile:52: recipe for target 'quickChickTool.byte' failed
make: *** [quickChickTool.byte] Error 10
make: *** Waiting for unfinished jobs....
W: This Makefile was generated by Coq 8.8.0
W: while the current Coq version is 8.9+alpha
COQC src/Tactics.v
COQC src/RandomQC.v
COQC src/RoseTrees.v
COQC src/ShowFacts.v
CAMLOPT -c -for-pack Quickchick_plugin src/genericLib.ml
CAMLOPT -pp -c -for-pack Quickchick_plugin src/quickChick.ml4
File "src/genericLib.ml", line 58, characters 21-38:
Error: This expression has type Libnames.qualid
       but an expression was expected of type
         Libnames.reference = Libnames.reference_r CAst.t
Makefile.coq:604: recipe for target 'src/genericLib.cmx' failed
make[2]: *** [src/genericLib.cmx] Error 2
make[2]: *** Waiting for unfinished jobs....
File "src/quickChick.ml4", line 14, characters 34-52:
Error: This expression has type Libnames.qualid
       but an expression was expected of type
         Libnames.reference = Libnames.reference_r CAst.t
Makefile.coq:596: recipe for target 'src/quickChick.cmx' failed
make[2]: *** [src/quickChick.cmx] Error 2
File "./src/ShowFacts.v", line 67, characters 2-14:
Warning: "intros until 0" is deprecated, use "intros *"; instead of
"induction 0" and "destruct 0" use explicitly a name."
[deprecated-intros-until-0,tactics]
Makefile.coq:317: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/home/jgross/Documents/repos/QuickChick'
Makefile:24: recipe for target 'plugin' failed
make: *** [plugin] Error 2
```