### PR TITLE
Prepare for porting to lia

### DIFF
--- a/src/Tactics.v
+++ b/src/Tactics.v
@@ -1,7 +1,8 @@
 Set Warnings "-extraction-opaque-accessed,-extraction".
 Set Warnings "-notation-overridden,-parsing".
 
-Require Import mathcomp.ssreflect.ssreflect Coq.omega.Omega.
+Require Import Coq.ZArith.ZArith.
+Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool ssrnat eqtype seq.
 
 Ltac inv H := inversion H; subst.


### PR DESCRIPTION
This backward-compatible patch prepares QuickChick for
https://github.com/coq/coq/pull/7878