### PR TITLE
Simpler framework for mutation testing

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -21,6 +21,7 @@ src/Checker.v
 src/SemChecker.v
 src/Test.v
 src/ExtractionQC.v
+src/Mutation.v
 src/tactic_quickchick.ml4
 src/quickchick_plugin.mlpack
 src/Typeclasses.v

--- a/scripts/quickchick
+++ b/scripts/quickchick
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Test mutated QuickChick test executable ($1)
+# quickchick-expectfailure must be findable in PATH
+
+QC_OUT_DIR=qc-out
+mkdir -p $QC_OUT_DIR/
+
+QC_ALL_MUTANTS_FILE=$QC_OUT_DIR/qc-mutants
+
+# Dynamic mutant discovery
+# TODO: allow mutants to be found via other means
+QC_MUTANT=DISCOVERY ./$1
+
+# Test each mutant
+cat $QC_ALL_MUTANTS_FILE|xargs -n 1 -I {} quickchick-expectfailure ./$1 {}

--- a/scripts/quickchick-expectfailure
+++ b/scripts/quickchick-expectfailure
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Run a QuickChick test executable ($1) with a given mutant ($2) and ensure at
+# least one test fails.
+
+set -e
+
+QC_OUT_DIR=qc-out
+mkdir -p $QC_OUT_DIR/
+
+LOG_FILE=$QC_OUT_DIR/testlog-${1##*/}-${2##*/}
+
+echo "Mutant $2: testing..."
+QC_MUTANT=$2 $1 > $LOG_FILE
+grep -q '^*** Failed' $LOG_FILE \
+  || (echo "Mutant $2: Tests passed, but failure was expected"; exit 1)
+echo "Mutant $2: killed!"

--- a/src/Mutation.v
+++ b/src/Mutation.v
@@ -1,0 +1,93 @@
+Require Extraction.
+
+(* Simple mutation testing framework for Coq.
+
+   A Gallina expression [a] with one or more mutants [b] or
+   [b1 .. bn] can be written as follows:
+
+       mutant! a b
+       mutants! a (b1, .. , bn)
+
+   In an interactive session, [mutant! a b] and
+   [mutants! a (b1, .. , bn)] both reduce to [a] (mutations
+   are ignored).
+
+   In extracted OCaml code however, those mutations can be
+   selected via the environment variable [QC_MUTANT]. *)
+
+(* - If [QC_MUTANT] is empty, the program executes normally,
+     without mutations.
+   - If [QC_MUTANT=DISCOVERY], the program executes normally,
+     but also writes identifiers for reachable mutants into
+     a file [./qc-mutants].
+   - If [QC_MUTANT=(mutantid)] where [(mutantid)] is one of those
+     identifiers, the program executes using that mutation.
+
+   A typical usage is to run the program once with [DISCOVERY]:
+
+       $ QC_MUTANT=DISCOVERY ./MyTestProgram
+
+   Then we can test each mutant using [xargs]:
+
+       $ cat qc-mutants|xargs -I {} -n 1 env QC_MUTANT={} ./MyTestProgram
+
+   Mutants can also be enumerated statically by looking for the
+   [__POS__] token in the extracted OCaml source code.
+
+   The script [quickchick-expectfailure] (under [scripts/]) can be used to
+   ensure a QuickChick test fails.
+
+       $ cat qc-mutants|xargs -I {} -n 1 env quickchick-expectfailure ./MyTestProgram {}
+
+   Note that definitions should not be simplified using [Eval] for
+   this to work...
+ *)
+
+(** * Implementation. *)
+
+Module Magic.
+
+Parameter loc : Type.
+Parameter HERE : loc.
+
+Definition mutation : loc -> bool := fun _ => false.
+
+Definition mutate : forall a, loc -> (unit -> a) -> (unit -> a) -> a :=
+  fun _ l f g => if mutation l then g tt else f tt.
+
+Extract Constant loc => "string * int * int * int".
+
+Extract Inlined Constant HERE => "__POS__".
+
+Extract Constant mutation =>
+  "let serialize_loc (locf,locl,locc,_) =
+     Printf.sprintf ""%s:%d:%d"" locf locl locc in 
+   match Sys.getenv_opt ""QC_MUTANT"" with
+   | None -> fun _ -> false
+   | Some ""DISCOVERY"" ->
+     let mutant_log = open_out ""qc-out/qc-mutants"" in
+     let mutants = Hashtbl.create 10 in
+     fun loc ->
+        begin match Hashtbl.find_opt mutants loc with
+        | None ->
+            Hashtbl.add mutants loc ();
+            output_string mutant_log (serialize_loc loc);
+            output_char mutant_log '\n';
+            flush mutant_log
+        | Some () -> ()
+        end; false
+   | Some this_mutant ->
+     (* print_string this_mutant; *) (* Debugging *)
+     fun loc -> serialize_loc loc = this_mutant".
+
+End Magic.
+
+Notation "'mutant!' a b" :=
+  (Magic.mutate _ Magic.HERE (fun _ => a) (fun _ => b))
+(at level 1, a at level 1, no associativity).
+
+Notation "'mutants!' a ( b1 , .. , bn )" :=
+  (mutant!
+     ( .. (mutant! a bn) .. )
+     b1)
+(at level 1, a at level 1, no associativity).

--- a/src/QuickChick.v
+++ b/src/QuickChick.v
@@ -50,6 +50,7 @@ Require Export Classes.
 Require Export Instances.
 Require Export DependentClasses.
 Require Export Typeclasses.
+Require Export Mutation.
 Export GenLow GenHigh.
 
 (* TODO: Figure out better place for these *)

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,4 @@
+*.ml
+*.mli
+*.native
+qc-mutants

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,10 @@
+TESTS=mutation.test
+
+.PHONY: test $(TESTS)
+
+test: $(TESTS)
+
+MUTATION=mutation
+
+mutation.test:
+	cd $(MUTATION)/; sh $(MUTATION).sh

--- a/test/mutation/mutation.sh
+++ b/test/mutation/mutation.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+MUTATION=mutation
+
+# Extract and compile the example
+coqc -Q ../../src QuickChick ${MUTATION}.v
+ocamlbuild ${MUTATION}.native
+
+# Look for mutants and test them
+PATH=../../scripts:$PATH quickchick ./${MUTATION}.native

--- a/test/mutation/mutation.v
+++ b/test/mutation/mutation.v
@@ -1,0 +1,15 @@
+From QuickChick Require Import QuickChick.
+Require Import String.
+Require Import ExtrOcamlNatInt.
+
+Definition prop_example :=
+  let x := mutant! 10 20 in
+  let y := mutants! 1 (2,3,4) in
+  whenFail (show x ++ " + " ++ show y ++ " <> 11")%string
+           (x + y = 11 ?).
+
+Definition main :=
+  print_extracted_coq_string
+    (show (quickCheck prop_example)).
+
+Extraction "mutation.ml" main.


### PR DESCRIPTION
The gist is: compile once, get all the mutants in the final executable. See comments in `src/Mutation.v`.

With this PR I also propose a simplification of `quickChickTool`.

The main nontrivial thing `quickChickTool` does that I would like to remove is the generation of `QuickChickTop.v`. Indeed, it is quite difficult to automate the following tasks correctly (currently very rigid assumptions are made about how the project is set up for this, and in `DeepWeb`/`dsss18/dw` they caused a lot of problems):

- mapping filepaths to logical paths in order to import properties found in `(*! QuickChick ... *)` comments;
- injecting `QuickChickTop.v` into the build system.

In fact, I don't think that work is worth automating in the first place: if users are willing to write `(*! QuickChick ... *)` comments, they might as well gather them in an actual Coq file that can be compiled as part of their normal build pipeline.

The other thing that `quickChickTool` does is to find mutants and test them.  This PR makes that much easier.

- To find mutants we can either look for the `mutant!` or `mutants!` token in `.v` files (currently only works to count them, TODO), or `__POS__` in the extracted `.ml` (TODO), or run the test executable once by setting the environment variable `QC_MUTANT=DISCOVERY`.
- To test mutants it is not necessary to modify the Coq sources or to recompile each mutant. They're all already in the compiled program and can be enabled by setting an environment variable properly.
