### PR TITLE
[coq] Fix more incomplete open of packed plugin modules.

### DIFF
--- a/src/genSTCorrect.ml
+++ b/src/genSTCorrect.ml
@@ -1,7 +1,6 @@
 open Pp
 open Loc
 open Names
-open Extract_env
 open Tacmach
 open Entries
 open Declarations
@@ -21,6 +20,8 @@ open SemLib
 open Unify
 open ArbitrarySizedST
 open Feedback
+
+open Extraction_plugin.Extract_env
 
 let appinst mthd inst s inps =
   gApp ~explicit:true (gInject mthd) [hole; hole; gApp inst inps; s]

--- a/src/sizedProofs.ml
+++ b/src/sizedProofs.ml
@@ -1,7 +1,6 @@
 open Pp
 open Loc
 open Names
-open Extract_env
 open Tacmach
 open Entries
 open Declarations
@@ -18,6 +17,8 @@ open CoqLib
 open GenLib
 open Error
 open Unify
+
+open Extraction_plugin.Extract_env
 
 type btyp = ((coq_expr -> coq_expr -> int -> (coq_expr * coq_expr) list -> (coq_expr -> coq_expr) -> coq_expr) *
              ((coq_expr -> (coq_expr * coq_expr) list -> coq_expr) -> coq_expr -> (coq_expr * coq_expr) list -> coq_expr))


### PR DESCRIPTION
Opening of plugin modules must be properly scoped. Unfortunately I
missed a couple more of cases in #117.

Technical note, this works due to bug in `coq_makefile` [but usually
may fail later at linking], but it will stop working soon.