### PR TITLE
Do not rely on `Refine Instance Mode`

### DIFF
--- a/src/CoArbitrary.v
+++ b/src/CoArbitrary.v
@@ -19,23 +19,25 @@ Class CoArbitrary (A : Type) : Type :=
     coarbCorrect : forall a, coarbReverse (coarbitrary a) = Some a
   }.
 
-Instance coArbPos : CoArbitrary positive := 
-  {|
+Instance coArbPos : CoArbitrary positive.
+Proof.
+refine {|
     coarbitrary x := x;
     coarbReverse x := Some x
   |}.
-Proof. auto. Qed.
+auto.
+Qed.
 
 Lemma nat_lemma :   forall a : nat,
   Some (Init.Nat.pred (Pos.to_nat (Pos.of_nat (S a)))) = Some a.
 Admitted.
 
-Instance coqArbNat : CoArbitrary nat := 
-  {|
+Instance coqArbNat : CoArbitrary nat.
+Proof.
+refine {|
     coarbitrary x := Pos.of_nat (S x);
     coarbReverse p := Some (Coq.Init.Peano.pred (Pos.to_nat p))
   |}.
-Proof.
   apply nat_lemma.
 Qed.
 

--- a/src/Decidability.v
+++ b/src/Decidability.v
@@ -64,15 +64,13 @@ Definition checker_backtrack (l : list (unit -> option bool)) : option bool :=
    change nothing... Or? *)
 
 (* Additional Checkable instance *)
-Global Instance testDec {P} `{H : Dec P} : Checkable P :=
-  {|
-    checker p := _
-  |}.
+Global Instance testDec {P} `{H : Dec P} : Checkable P.
 Proof.
+  constructor.
   destruct H.
   destruct dec0.
-  - exact (checker true).
-  - exact (checker false).
+  - intros; exact (checker true).
+  - intros; exact (checker false).
 Defined.
 
 Global Instance Dec_neg {P} {H : Dec P} : Dec (~ P).
@@ -139,11 +137,11 @@ Ltac dec_eq :=
            end
          end.
 
-Global Instance Eq__Dec {A} `{H : Dec_Eq A} (x y : A) : Dec (x = y) :=
-  {|
-    dec := _
-  |}.
-Proof. dec_eq. Defined.
+Global Instance Eq__Dec {A} `{H : Dec_Eq A} (x y : A) : Dec (x = y).
+Proof.
+constructor.
+dec_eq.
+Defined.
 
 (* Lifting common decidable instances *)
 Global Instance Dec_eq_unit (x y : unit) : Dec (x = y).

--- a/src/Typeclasses.v
+++ b/src/Typeclasses.v
@@ -12,9 +12,9 @@ Import GenLow GenHigh.
 Instance arbST_eq {A} (a : A) : GenSuchThat A (fun x => x = a) :=
   {| arbitraryST := returnGen (Some a) |}.
 Instance arbST_Correct {A} (a : A) 
-  : SuchThatCorrect (fun x => x = a) (genST (fun x => x = a)) :=
-  {| STCorrect := _ |}.
+  : SuchThatCorrect (fun x => x = a) (genST (fun x => x = a)).
 Proof.
+  constructor.
   simpl; rewrite semReturn.
   split; intros H. now firstorder.
   destruct H as [x [Heq H]]. subst. inversion H. subst.
@@ -24,9 +24,9 @@ Defined.
 Instance arbST_eq' {A} (a : A) : GenSuchThat A (fun x => a = x) :=
   {| arbitraryST := returnGen (Some a) |}.
 Instance arbST_Correct' {A} (a : A) 
-  : SuchThatCorrect (fun x => a = x ) (genST (fun x => a = x)) :=
-  {| STCorrect := _  |}.
+  : SuchThatCorrect (fun x => a = x ) (genST (fun x => a = x)).
 Proof.
+  constructor.
   simpl; rewrite semReturn.
   split; intros H. now firstorder.
   destruct H as [x [Heq H]]. subst. inversion H. subst.
@@ -43,10 +43,11 @@ Ltac ignore_gen_proofs := exfalso; apply ignore_generator_proofs.
 Global Instance testSuchThat {A : Type} {pre : A -> Prop} {prop : A -> Type}
        `{Show A} `{GenSuchThat A (fun x => pre x)}
        `{forall (x : A), Checkable (prop x)} :
-  Checkable (forall x, pre x -> prop x) := 
+  Checkable (forall x, pre x -> prop x).
+Proof.
+refine
   {| checker f := forAllMaybe (genST (fun x => pre x))
                               (fun x => checker (f x _)) |}.
-Proof.
   ignore_gen_proofs.
 Defined.
 
@@ -55,12 +56,15 @@ Global Instance testSuchThat2
        `{Show A} `{Show B} 
        `{GenSuchThat (A * B) (fun x => let (a,b) := x in pre a b)}
        `{forall (a : A) (b : B), Checkable (prop a b)} :
-  Checkable (forall a b , pre a b -> prop a b) :=
+  Checkable (forall a b , pre a b -> prop a b).
+Proof.
+refine
   {| checker f := forAllMaybe (genST (fun x : A * B => let (a,b) := x in pre a b))
                               (fun x =>
                                  let (a,b) := x in
                                  checker (f a b _)) |}.
-Proof. ignore_gen_proofs. Defined.
+ignore_gen_proofs.
+Defined.
 
 
 (*


### PR DESCRIPTION
This option is soon going to be turned off by default. See
https://github.com/coq/coq#9270

This patch should be backward compatible. It wasn't 100% clear to me on which branch I base it, even after reading the contributing guide.