### PR TITLE
Make trivial instances explicit

### DIFF
--- a/src/Classes.v
+++ b/src/Classes.v
@@ -168,29 +168,29 @@ Class GenMonotonicCorrect (A : Type)
   
 Instance GenSizedMonotonicOfSizeMonotonic
          (A : Type) (Hgen : GenSized A) (Hmon : forall s, @SizeMonotonic A (arbitrarySized s))
-: @GenSizedMonotonic A Hgen Hmon.
+: @GenSizedMonotonic A Hgen Hmon := {}.
   
 Instance GenMonotonicOfSizeMonotonic
          (A : Type) (Hgen : Gen A) (Hmon : @SizeMonotonic A arbitrary)
-: @GenMonotonic A Hgen Hmon.
+: @GenMonotonic A Hgen Hmon := {}.
 
 Instance GenSizedCorrectOfSizedCorrect
          (A : Type) (Hgen : GenSized A) `{Hcor : SizedCorrect A arbitrarySized}
-: @GenSizedCorrect A Hgen _ Hcor.
+: @GenSizedCorrect A Hgen _ Hcor := {}.
 
 Instance GenCorrectOfCorrect
          (A : Type) (Hgen : Gen A) `{Hcor : Correct A arbitrary}
-: @GenCorrect A Hgen Hcor.
+: @GenCorrect A Hgen Hcor := {}.
 
 Instance GenSizedSizeMonotonicOfSizedMonotonic
          (A : Type) (Hgen : GenSized A) (Hmon : @SizedMonotonic A arbitrarySized)
-: @GenSizedSizeMonotonic A Hgen Hmon.
+: @GenSizedSizeMonotonic A Hgen Hmon := {}.
 
 (* Zoe : Is global really needed here? *)
 Global Instance GenOfGenSized {A} `{GenSized A} : Gen A :=
   {| arbitrary := sized arbitrarySized |}.
 
-Global Instance ArbitraryOfGenShrink {A} `{Gen A} `{Shrink A} : Arbitrary A.
+Global Instance ArbitraryOfGenShrink {A} `{Gen A} `{Shrink A} : Arbitrary A := {}.
 
 Generalizable Variables PSized PMon PSMon PCorr.
 
@@ -198,7 +198,7 @@ Instance GenMonotonicOfSized (A : Type)
          {H : GenSized A}
          `{@GenSizedMonotonic A H PMon}
          `{@GenSizedSizeMonotonic A H PSMon}
-: GenMonotonic A.
+: GenMonotonic A := {}.
 
 Instance GenCorrectOfSized (A : Type)
          {H : GenSized A}

--- a/src/DependentClasses.v
+++ b/src/DependentClasses.v
@@ -89,28 +89,28 @@ Class GenSuchThatMonotonicCorrect (A : Type) (P : A -> Prop)
 Instance GenSizedSuchThatMonotonicOptOfSizeMonotonic
          (A : Type) (P : A -> Prop) (Hgen : GenSizedSuchThat A P)
          (Hmon : forall s : nat, SizeMonotonicOpt (arbitrarySizeST s))
-: @GenSizedSuchThatMonotonicOpt A _ Hgen Hmon.
+: @GenSizedSuchThatMonotonicOpt A _ Hgen Hmon := {}.
 
 Instance GenSizedSuchThatSizeMonotonicOptOfSizedMonotonic
          (A : Type) (P : A -> Prop) (Hgen : GenSizedSuchThat A P)
          (Hmon : SizedMonotonicOpt arbitrarySizeST)
-: @GenSizedSuchThatSizeMonotonicOpt A _ Hgen Hmon.
+: @GenSizedSuchThatSizeMonotonicOpt A _ Hgen Hmon := {}.
 
 Instance GenSizedSuchThatCorrectOptOfSizedSuchThatCorrect
          (A : Type) (P : A -> Prop) (H : GenSizedSuchThat A P)
          (Heqs : SizedProofEqs P)
          (Hcorr : SizedSuchThatCorrect P arbitrarySizeST)
-: @GenSizedSuchThatCorrect A P H Heqs Hcorr.
+: @GenSizedSuchThatCorrect A P H Heqs Hcorr := {}.
 
 Instance GenSuchThatMonotonicOptOfSizeMonotonic
          (A : Type) (P : A -> Prop) (Hgen : GenSuchThat A P)
          (Hmon : SizeMonotonicOpt arbitraryST)
-: @GenSuchThatMonotonicOpt A _ Hgen Hmon.
+: @GenSuchThatMonotonicOpt A _ Hgen Hmon := {}.
 
 Instance GenSuchThatCorrectOptOfSuchThatCorrect
          (A : Type) (P : A -> Prop) (H : GenSuchThat A P)
          (Hcorr : SuchThatCorrect P (genST P))
-: @GenSuchThatCorrect A P H Hcorr.
+: @GenSuchThatCorrect A P H Hcorr := {}.
 
 Instance SizeMonotonicOptofSizeMonotonic {A} (g : G (option A))
          {H : SizeMonotonic g} : SizeMonotonicOpt g.
@@ -136,7 +136,7 @@ Instance GenSuchThatMonotonicOfSized (A : Type) (P : A -> Prop)
          {H : GenSizedSuchThat A P}
          `{@GenSizedSuchThatMonotonic A P H PMon}
          `{@GenSizedSuchThatSizeMonotonic A P H PSMon}
-: GenSuchThatMonotonic A P.
+: GenSuchThatMonotonic A P := {}.
 
 
 Instance SizeMonotonicOptOfBounded' (A : Type) (P : A -> Prop)
@@ -166,7 +166,7 @@ Instance GenSuchThatMonotonicOptOfSized' (A : Type) (P : A -> Prop)
          {H : GenSizedSuchThat A P}
          `{@GenSizedSuchThatMonotonicOpt A P H PMon}
          `{@GenSizedSuchThatSizeMonotonicOpt A P H PSMon}
-: GenSuchThatMonotonicOpt A P.
+: GenSuchThatMonotonicOpt A P := {}.
 
 (* Correctness *)
 Instance SuchThatCorrectOfBounded' (A : Type) (P : A -> Prop)


### PR DESCRIPTION
This is in preparation for coq/coq#9274.

Should be backward compatible but that remains to be tested.