### PR TITLE
[coq_makefile] Some more fixes following #158

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ clean:
 	find . -name *.conflicts -print -delete
 	find . -name *.output -print -delete
 	find . -name *.aux -print -delete
-	rm -f Makefile.coq*
+	rm -f Makefile.coq Makefile.coq.conf
 
 bc:
 	coqwc src/*.v

--- a/src/weightmap.mlg
+++ b/src/weightmap.mlg
@@ -57,8 +57,8 @@ let convert_constr_to_cw_pair c : (constructor * weight_ast) =
 let register_weights_object = 
   Libobject.declare_object
     {(Libobject.default_object ("QC_register_weights")) with
-       cache_function = (fun (_,ws) -> register_weights ws);
-       load_function = (fun _ (_,ws) -> register_weights ws)}
+      Libobject.cache_function = (fun (_,ws) -> register_weights ws);
+      Libobject.load_function = (fun _ (_,ws) -> register_weights ws)}
 
 let lookup_weight ctr size_var = 
   try match CtrMap.find ctr !weight_env with


### PR DESCRIPTION
This PR fixes a couple of issues forgotten or introduces in #158, in
particular we should not clean the `Makefile.coq.local` file, and we
forgot a warning in an `.mlg` [due to editing the wrong file].