### PR TITLE
Reduce dependencies of quickChickTool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ src/%.cmo : src/%.ml
 quickChickTool: $(QCTOOL_DIR)/$(QCTOOL_EXE)
 
 $(QCTOOL_DIR)/$(QCTOOL_EXE): $(QCTOOL_SRC)
-	cd $(QCTOOL_DIR); ocamlbuild -use-ocamlfind $(QCTOOL_EXE)
+	cd $(QCTOOL_DIR); ocamlbuild -pkg unix -use-ocamlfind $(QCTOOL_EXE)
 
 tests:
 #	$(MAKE) -C examples/ifc-basic test

--- a/quickChickTool/_tags
+++ b/quickChickTool/_tags
@@ -1,1 +1,1 @@
-true: package(coq.lib), rectypes, thread, traverse
+true: rectypes, thread, traverse

--- a/quickChickTool/quickChickToolLexer.mll
+++ b/quickChickTool/quickChickToolLexer.mll
@@ -6,7 +6,7 @@ open QuickChickToolTypes
 (* Function to increase line count in lexbuf *)
 let line_incs s lexbuf =
 (*  Printf.printf "Read: %s\n" s; *)
-  let splits = Str.split_delim (Str.regexp "\n") s in 
+  let splits = String.split_on_char '\n' s in
   let pos = lexbuf.Lexing.lex_curr_p in
 (* Printf.printf "Was in line %d, position %d\n" pos.pos_lnum (pos.pos_cnum - pos.pos_bol); *)
   lexbuf.Lexing.lex_curr_p <- {


### PR DESCRIPTION
Removes dependency on libraries coqlib (internal Coq library), str, and module `Option` (only since ocaml 4.08).

Fixes #103.
