### PR TITLE
plugin: Remove dependency on str and Option

### DIFF
--- a/src/genericLib.ml
+++ b/src/genericLib.ml
@@ -221,6 +221,11 @@ let rec dep_type_len = function
   | _ -> 0
 
 (* Option monad *)
+let option_map f ox =
+  match ox with
+  | Some x -> Some (f x)
+  | None -> None
+
 let (>>=) m f = 
   match m with
   | Some x -> f x 
@@ -439,7 +444,7 @@ let parse_dependent_type i nparams ty oib arg_names =
 (*      let (mp, _dn, _) = MutInd.repr3 mind in *)
 
       (* HACKY: figure out better way to qualify constructors *)
-      let names = Str.split (Str.regexp "[.]") (MutInd.to_string mind) in
+      let names = String.split_on_char '.' (MutInd.to_string mind) in
       let prefix = List.rev (List.tl (List.rev names)) in
       let qual = String.concat "." prefix in
       msg_debug (str (Printf.sprintf "CONSTR: %s %s" qual (DirPath.to_string (Lib.cwd ()))) ++ fnl ());

--- a/src/genericLib.mli
+++ b/src/genericLib.mli
@@ -105,6 +105,7 @@ val dep_type_len : dep_type -> int
 val dep_result_type : dep_type -> dep_type
 
 (* option type helpers *)
+val option_map : ('a -> 'b) -> 'a option -> 'b option
 val (>>=) : 'a option -> ('a -> 'b option) -> 'b option                                   
 val isSome : 'a option -> bool
 val cat_maybes : 'a option list -> 'a list

--- a/src/simplDriver.ml
+++ b/src/simplDriver.ml
@@ -29,15 +29,15 @@ let derivable_to_string = function
   | SizeMonotonic -> "SizeMonotonic"
   | SizedMonotonic -> "SizedMonotonic"
   | SizedCorrect ->  "SizedCorrect"
-  
+
 let mk_instance_name der tn = 
   let prefix = derivable_to_string der in
-  let strip_last s = List.hd (List.rev (Str.split (Str.regexp "[.]") s)) in
+  let strip_last s = List.hd (List.rev (String.split_on_char '.' s)) in
   var_to_string (fresh_name (prefix ^ strip_last tn))
 
 let repeat_instance_name der tn = 
   let prefix = derivable_to_string der in
-  let strip_last s = List.hd (List.rev (Str.split (Str.regexp "[.]") s)) in
+  let strip_last s = List.hd (List.rev (String.split_on_char '.' s)) in
   (prefix ^ strip_last tn)
 
 (* Generic derivation function *)

--- a/src/unify.ml
+++ b/src/unify.ml
@@ -238,9 +238,9 @@ let rec convert_to_range dt =
   match dt with 
   | DTyVar x -> Some (Unknown x)
   | DCtr (c,dts) ->
-     Option.map (fun dts' -> Ctr (c, dts')) (sequenceM convert_to_range dts)
+     option_map (fun dts' -> Ctr (c, dts')) (sequenceM convert_to_range dts)
   | DTyCtr (c, dts) -> 
-     Option.map (fun dts' -> Ctr (ty_ctr_to_ctr c, dts')) (sequenceM convert_to_range dts)
+     option_map (fun dts' -> Ctr (ty_ctr_to_ctr c, dts')) (sequenceM convert_to_range dts)
   | _ -> None
 
 let is_fixed k dt = 
@@ -250,7 +250,7 @@ let is_fixed k dt =
     | Unknown u' -> aux (umfind u' k)
     | Ctr (_, rs) -> List.for_all aux rs
     | RangeHole -> true (*TODO *)
-  in Option.map aux (convert_to_range dt)
+  in option_map aux (convert_to_range dt)
 
 (* convert a range to a coq expression *)
 let rec range_to_coq_expr k r = 
@@ -268,7 +268,7 @@ let rec range_to_coq_expr k r =
   | _ -> failwith "QC Internal: TopLevel ranges should be Unknowns or Constructors"
 
 let dt_to_coq_expr k dt = 
-  Option.map (range_to_coq_expr k) (convert_to_range dt)
+  option_map (range_to_coq_expr k) (convert_to_range dt)
 
 let rec is_dep_type = function
   | DArrow (dt1, dt2) -> is_dep_type dt1 || is_dep_type dt2 


### PR DESCRIPTION
`Option` is only available since OCaml 4.08 (how did it go through CI?) and str is weird (like unix, but that's harder to avoid) so avoiding it is one less headache when you don't have a proper dependency resolver.