### PR TITLE
fix div/mod extraction

### DIFF
--- a/src/ExtractionQC.v
+++ b/src/ExtractionQC.v
@@ -62,7 +62,7 @@ Extract Constant force => "Lazy.force".
 
 (* Extract Constant Test.ltAscii => "(<=)". *)
 (* Extract Constant Test.strEq   => "(=)". *)
-Extract Constant Nat.div => "(/)".
+Extract Constant Nat.div => "(fun m -> function 0 -> 0 | d -> m / d)".
 Extract Constant Test.gte => "(>=)".
 Extract Constant le_gt_dec => "(<=)".
 Extract Constant trace =>
@@ -77,8 +77,8 @@ Set Extraction AccessOpaque.
 
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssreflect ssrnat ssrbool div eqtype.
-Extract Constant divn => "(/)".
-Extract Constant modn => "(fun x y -> x mod y)".
+Extract Constant divn => "(fun m -> function 0 -> 0 | d -> m / d)".
+Extract Constant modn => "(fun m -> function 0 -> 0 | d -> m mod d)".
 Extract Constant eqn => "(==)".
 
 Axiom print_extracted_coq_string : string -> unit.


### PR DESCRIPTION
Getting ocaml’s `Fatal error: exception Division_by_zero` instead of `+++ Passed 10000 tests` was somewhat unexpected.
