### PR TITLE
Adapting to Coq PR#10832 (extra scope argument to CNotation).

### DIFF
--- a/src/driver.mlg
+++ b/src/driver.mlg
@@ -45,7 +45,7 @@ let dispatch cn ind name1 name2 =
     | {CAst.v = CRef (r, _) ; _} -> string_of_qualid r
     | _ -> failwith "Usage: Derive <class_name> for <inductive_name> OR  Derive (<class_name>, ... , <class_name>) for <inductive_name>" in
   let ss = match cn with
-     | { CAst.v = CNotation (_,([a],[b],_,_)); _ } -> begin
+     | { CAst.v = CNotation (_,_,([a],[b],_,_)); _ } -> begin
          let c = convert_reference_to_string a in
          let cs = List.map convert_reference_to_string b in
          c :: cs

--- a/src/weightmap.mlg
+++ b/src/weightmap.mlg
@@ -43,7 +43,7 @@ let convert_constr_to_weight c =
 
 let convert_constr_to_cw_pair c : (constructor * weight_ast) = 
   match c with 
-  | { CAst.v = CNotation (_,([a],[[b]],_,_)); _ } -> begin
+  | { CAst.v = CNotation (_,_,([a],[[b]],_,_)); _ } -> begin
       let ctr = 
         match a with 
         | { CAst.v = CRef (r, _); _ } -> injectCtr (string_of_qualid r)
@@ -73,7 +73,7 @@ VERNAC COMMAND EXTEND QuickChickWeights CLASSIFIED AS SIDEFF
      {
        let weight_assocs = 
          match c with 
-         | { CAst.v = CNotation (_,([a],[b],_,_)); _ } -> begin
+         | { CAst.v = CNotation (_,_,([a],[b],_,_)); _ } -> begin
              let c = convert_constr_to_cw_pair a in
              let cs = List.map convert_constr_to_cw_pair b in
              c :: cs


### PR DESCRIPTION
Hi, QuickChick is part of Coq CI and to keep it consistent with our tests, the attached change will have to be applied at the time [Coq PR#10932](https://github.com/coq/coq/pull/10832) is merged.

Coq PR#10932 adds an extra argument to the `CNotation` constructor and this PR is to adapt QuickChick `mlg` files to this change.

Note that the purpose of Coq PR#10932 is to fix attach formats to specific interpretations of notations. In particular, this fixes [Coq issue #6082](https://github.com/coq/coq/issues/6082).