### PR TITLE
Adapt to Coq PR11141

### DIFF
--- a/src/tactic_quickchick.mlg
+++ b/src/tactic_quickchick.mlg
@@ -26,7 +26,7 @@ let quickchick_goal =
     Printf.printf "So far so good\n"; flush stdout;
     
     (* Externalize it *)
-    let ct = Constrextern.extern_constr false e evd (EConstr.mkEvar (evar , [||])) in
+    let ct = Constrextern.extern_constr e evd (EConstr.mkEvar (evar , [||])) in
 
     (* Construct : show (quickCheck (_ : ct)) *)
     let qct =


### PR DESCRIPTION
Hi, Coq [PR#11141](https://github.com/coq/coq/pull/11141) simplifies the organization of options to printing functions (including `extern_constr`) thanks to labels.

This QuickQuick PR is to adapt to the Coq PR (an argument to remove in `extern_constr`). Since QuickChick is tested in the Coq Continuous Integration, it should be merged synchronously with the Coq PR (the assignee is @ejgallego). Thanks!