### PR TITLE
Better fix for Decimal.int extraction

### DIFF
--- a/src/ExtractionQC.v
+++ b/src/ExtractionQC.v
@@ -13,9 +13,12 @@ Require Import ExtrOcamlZInt.
 
 Extraction Blacklist String List Nat.
 
-(** Temporary fix for https://github.com/coq/coq/issues/7017.
-    See [define_and_run] in `quickChick.ml4` for definition of [M] module. *)
-Extract Inductive Decimal.int => "((uint, uint) M.sum)" ["M.Inl" "M.Inr"].
+(** Temporary fix for https://github.com/coq/coq/issues/7017. *)
+(** Scott encoding of [Decimal.int] as [forall r. (uint -> r) -> (uint -> r) -> r]. *)
+Extract Inductive Decimal.int => "((Obj.t -> Obj.t) -> (Obj.t -> Obj.t) -> Obj.t) (* Decimal.int *)"
+  [ "(fun x pos _ -> pos (Obj.magic x))"
+    "(fun y _ neg -> neg (Obj.magic y))"
+  ] "(fun i pos neg -> Obj.magic i pos neg)".
 
 Extract Constant show_nat =>
   "(fun i ->

--- a/src/quickChick.mlg
+++ b/src/quickChick.mlg
@@ -158,11 +158,6 @@ let define_and_run c env evd =
   (*
   msg_debug (str "Extracted ML file: " ++ str mlf);
   msg_debug (str "Compile command: " ++ str (comp_ml_cmd mlf execn));
-   *)
-  let oc' : out_channel = open_out (Filename.concat dir "m.ml") in
-  output_string oc' "type ('a, 'b) sum = Inl of 'a | Inr of 'b";
-  close_out oc';
-  (*
   Printf.printf "Extracted ML file: %s\n" mlf;
   Printf.printf "Compile command: %s\n" (comp_ml_cmd mlf execn);
   flush_all ();


### PR DESCRIPTION
No longer depend on an external file, which can break other people's workflow.

This is also a better fix than the [old one](https://github.com/QuickChick/QuickChick/commit/dadabe5971ed87d78c6653c5abe3d3a20a8f1c35) (the fix before the previous one) which crippled `int`.

See #193. I'm not sure this PR alone resolves the issue entirely given that the problem still exists on 1.2.0 which is what you will get on 8.10. What's a good way to backport bugfixes? Make a `v1.2.1`?

Also, ideally, QuickChick should not be the one changing extraction of standard data types, but that's going to take more time to figure out.