### PR TITLE
omega -> lia (continued)

### DIFF
--- a/src/GenHighImpl.v
+++ b/src/GenHighImpl.v
@@ -1,10 +1,8 @@
 Set Warnings "-extraction-opaque-accessed,-extraction".
 Set Warnings "-notation-overridden,-parsing".
 
-Require Import String. 
-Require Import List.
-
-Require Import ZArith.
+From Coq Require Import
+  String List ZArith Lia.
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool ssrnat eqtype seq.
 
@@ -546,8 +544,8 @@ Lemma In_nth_exists {A} (l: list A) x def :
 Proof.
 elim : l => [| a l IHl] //=.
 move => [H | /IHl [n [H1 H2]]]; subst.
-  exists 0; split => //; omega.
-exists n.+1; split => //; omega.
+  exists 0; split => //; lia.
+exists n.+1; split => //; lia.
 Qed.
 
 Lemma nth_imset T (def : T) l : nth def l @: [set n | n < length l] <--> l.

--- a/src/Instances.v
+++ b/src/Instances.v
@@ -6,7 +6,8 @@ From Coq Require Import
      Basics
      List
      Recdef
-     ZArith.
+     ZArith
+     Lia.
 From mathcomp Require Import
      ssrbool
      ssreflect
@@ -82,9 +83,9 @@ Function shrinkNatAux (x : nat) {measure (fun x => x) x} : list nat :=
 Proof.
   move => x n Eq;
   pose proof (Nat.divmod_spec n 1 0 0) as H.
-  assert (H' : (0 <= 1)%coq_nat) by omega; apply H in H';
+  assert (H' : (0 <= 1)%coq_nat) by lia; apply H in H';
   subst; simpl in *; clear H.
-  destruct (Nat.divmod n 1 0 0) as [q u];  destruct u; simpl in *; omega.
+  destruct (Nat.divmod n 1 0 0) as [q u];  destruct u; simpl in *; lia.
 Defined.
 
 Global Instance shrinkNat : Shrink nat :=
@@ -97,10 +98,10 @@ Proof.
     rewrite /Z.div2 /Pos.div2.
       rewrite /Z.abs_nat. rewrite Pos2Nat.inj_xI.
       rewrite <- Nat.add_1_r. rewrite mult_comm.
-      rewrite Nat.div2_div. rewrite Nat.div_add_l; simpl; omega.
+      rewrite Nat.div2_div. rewrite Nat.div_add_l; simpl; lia.
     rewrite /Z.div2 /Pos.div2.
       rewrite /Z.abs_nat. rewrite Pos2Nat.inj_xO.
-      rewrite mult_comm. rewrite Nat.div2_div. rewrite Nat.div_mul. reflexivity. omega.
+      rewrite mult_comm. rewrite Nat.div2_div. rewrite Nat.div_mul. reflexivity. lia.
   reflexivity.
 Qed.
 
@@ -137,11 +138,11 @@ Proof.
     left. rewrite /Z.div2 /Pos.div2.
       rewrite neg_succ. rewrite <- Zsucc_pred. rewrite /Z.abs_nat. rewrite Pos2Nat.inj_xI.
       rewrite <- Nat.add_1_r. rewrite mult_comm.
-      rewrite Nat.div2_div. rewrite Nat.div_add_l; simpl; omega.
+      rewrite Nat.div2_div. rewrite Nat.div_add_l; simpl; lia.
     right. rewrite /Z.div2 /Pos.div2.
       rewrite Pos2Nat.inj_xO. rewrite mult_comm.
       rewrite Nat.div2_div. rewrite Nat.div_mul. simpl.
-      apply abs_succ_neg. omega.
+      apply abs_succ_neg. lia.
   left. simpl. reflexivity.
 Qed.
 
@@ -153,12 +154,12 @@ Function shrinkZAux (x : Z) {measure (fun x => Z.abs_nat x) x}: list Z :=
   end.
 Proof.
   move => ? p ?. subst. rewrite abs_div2_pos. rewrite Zabs2Nat.inj_pos.
-    rewrite Nat.div2_div. apply Nat.div_lt. apply Pos2Nat.is_pos. omega.
+    rewrite Nat.div2_div. apply Nat.div_lt. apply Pos2Nat.is_pos. lia.
   move => ? p ?. subst. destruct (abs_succ_div2_neg p) as [H | H].
     rewrite {}H /Z.abs_nat. rewrite Nat.div2_div.
-      apply Nat.div_lt. apply Pos2Nat.is_pos. omega.
+      apply Nat.div_lt. apply Pos2Nat.is_pos. lia.
     rewrite {}H /Z.abs_nat. eapply le_lt_trans. apply le_pred_n. rewrite Nat.div2_div.
-      apply Nat.div_lt. apply Pos2Nat.is_pos. omega.
+      apply Nat.div_lt. apply Pos2Nat.is_pos. lia.
 Qed.
 
 Global Instance shrinkZ : Shrink Z :=
@@ -203,7 +204,7 @@ Global Instance shrinkOption {A : Type} `{Shrink A} : Shrink (option A) :=
 Program Instance arbNatMon : SizeMonotonic (@arbitrary nat _).
 Next Obligation.
   rewrite !semSizedSize !semChooseSize // => n /andP [/leP H1 /leP H2].
-  move : H => /leP => Hle. apply/andP. split; apply/leP; omega.
+  move : H => /leP => Hle. apply/andP. split; apply/leP; lia.
 Qed.
 
 (** Correctness proof about built-in generators *)

--- a/src/Tactics.v
+++ b/src/Tactics.v
@@ -1,14 +1,15 @@
 Set Warnings "-extraction-opaque-accessed,-extraction".
 Set Warnings "-notation-overridden,-parsing".
 
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import
+  ZArith Lia.
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool ssrnat eqtype seq.
 
 Ltac inv H := inversion H; subst.
 
 
-(* omega for ssrnat, taken from https://github.com/pi8027/formalized-postscript/blob/master/stdlib_ext.v *)
+(* lia for ssrnat, taken from https://github.com/pi8027/formalized-postscript/blob/master/stdlib_ext.v *)
 
 Ltac arith_hypo_ssrnat2coqnat :=
   match goal with
@@ -34,4 +35,4 @@ Ltac arith_goal_ssrnat2coqnat :=
 Ltac ssromega :=
   repeat arith_hypo_ssrnat2coqnat;
   arith_goal_ssrnat2coqnat; simpl;
-  omega.
+  lia.


### PR DESCRIPTION
For real this time.

`git grep "\\<omega"` shows only occurrences in `sf-experiments` which is in a broken state anyway. (Note we also have a local `ssromega` tactic which is now defined in terms of `lia`).