### PR TITLE
Don't rely on setod rewrite forgetting arrow binder names (coq/coq#13882)

### DIFF
--- a/src/RandomQC.v
+++ b/src/RandomQC.v
@@ -265,7 +265,7 @@ inversion H; clear H.
 inversion H0; clear H0.
 generalize H1; clear H1.
 rewrite filter_In.
-intros.
+intros H0.
 inversion H0; clear H0.
 unfold tl in H.
 destruct x eqn:X.


### PR DESCRIPTION
This should be backwards compatible and so may be merged now.