### PR TITLE
Adapting to Coq PR #14598: adding an explicit constr_expr node for projections.

### DIFF
--- a/plugin/depDriver.ml
+++ b/plugin/depDriver.ml
@@ -296,10 +296,10 @@ let dep_dispatch ind class_name : unit =
     (* Extract (x1,x2,...) if any, P and arguments *)
     let (letbindsM, constructor, args) =
       match body with 
-      | { CAst.v = CApp ((_flag, constructor), args); _ } -> (None, constructor, args)
+      | { CAst.v = CApp (constructor, args); _ } -> (None, constructor, args)
       | { CAst.v = CLetTuple (name_list, _,
                               _shouldbeid,
-                              { CAst.v = CApp ((_flag, constructor), args); _ } ); _} ->
+                              { CAst.v = CApp (constructor, args); _ } ); _} ->
          ( Some (List.map (function { CAst.v = name; _ } -> name ) name_list), constructor, args )
     in
 
@@ -359,7 +359,7 @@ let dep_dispatch ind class_name : unit =
     derive_dependent class_name constructor init_umap init_tmap
       input_names input_ranges
       (ty_ctr, ty_params, ctrs, dep_type) letbinds idu 
-  | { CAst.v = CApp ((_flag, constructor), args); _ } ->
+  | { CAst.v = CApp (constructor, args); _ } ->
 
      msg_debug (str "Parsing constructor information for checker" ++ fnl ());
      

--- a/plugin/genericLib.ml
+++ b/plugin/genericLib.ml
@@ -560,7 +560,7 @@ let coerce_reference_to_dep_dt c =
 let gApp ?explicit:(expl=false) c cs =
   if expl then
     let f c = match c with
-    | CRef (r,_) -> CAppExpl ((None, r, None), cs)
+    | CRef (r,_) -> CAppExpl ((r, None), cs)
     | _ -> failwith "invalid argument to gApp"
     in CAst.map f c
   else mkAppC (c, cs)

--- a/plugin/quickChick.mlg
+++ b/plugin/quickChick.mlg
@@ -260,7 +260,7 @@ let runTest c env evd : unit =
   (* [c] is a constr_expr representing the test to run,
      so we first build a new constr_expr representing
      show c **)
-  let c = CAst.make @@ CApp((None,show), [(c,None)]) in
+  let c = CAst.make @@ CApp(show, [(c,None)]) in
   (* Build the kernel term from the const_expr *)
 
   (*  Printf.printf "Before interp constr\n"; flush stdout; *)
@@ -280,7 +280,7 @@ let run f args =
   | _ -> failwith "run called with no arguments"
   end;
   let args = List.map (fun x -> (x,None)) args in
-  let c = CAst.make @@ CApp((None,f), args) in
+  let c = CAst.make @@ CApp(f, args) in
   runTest c env evd
 
 let set_debug_flag (flag_name : string) (mode : string) =

--- a/plugin/tactic_quickchick.mlg
+++ b/plugin/tactic_quickchick.mlg
@@ -29,8 +29,8 @@ let quickchick_goal =
 
     (* Construct : show (quickCheck (_ : ct)) *)
     let qct =
-      (CAst.make @@ CApp((None,QuickChick.quickCheck), [ct, None])) in    
-    let sqct = CAst.make @@ CApp((None,QuickChick.show), [(qct,None)]) in
+      (CAst.make @@ CApp(QuickChick.quickCheck, [ct, None])) in    
+    let sqct = CAst.make @@ CApp(QuickChick.show, [(qct,None)]) in
 
     Printf.printf "So far so good2\n"; flush stdout;
 
@@ -72,7 +72,7 @@ let quickchick_goal =
                        ))) in
 
     let s = QuickChick.runTest
-            (CAst.make @@ CApp((None,QuickChick.quickCheck), [CAst.make @@ CRef (Libnames.qualid_of_ident tmpid,None), None])) in
+            (CAst.make @@ CApp(QuickChick.quickCheck, [CAst.make @@ CRef (Libnames.qualid_of_ident tmpid,None), None])) in
     (* I need to create an existential of type Checkable ct, and then
        call QuickChick.quickChick on that in the ast, before running
        QuickChick.runTest on the constr_expr. *)


### PR DESCRIPTION
The `CApp` and `CAppExpl` constructors lose the part of their syntax which served to encode projections and this leads to some simplifications.

This has to be merged synchrounously with coq/coq#14598. Thanks in advance.