### PR TITLE
plugin: Fix log message when calling QuickChickWith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ commands:
         name: Test dependants
         no_output_timeout: 20m
         command: |
+          if [ `opam list -s coq` != "coq.dev" ]; then
           PINS=$(echo `opam list -s --pinned --columns=package` | sed 's/ /,/g')
           PACKAGES=`opam list -s --depends-on coq-quickchick --coinstallable-with $PINS`
           for PACKAGE in $PACKAGES
@@ -82,6 +83,7 @@ commands:
              opam install --deps-only $PACKAGE || DEPS_FAILED=true
              [ $DEPS_FAILED == true ] || opam install -t $PACKAGE
           done
+          fi
   remove:
     steps:
     - run:

--- a/plugin/quickChick.mlg.cppo
+++ b/plugin/quickChick.mlg.cppo
@@ -246,14 +246,19 @@ let runTest c env evd : unit =
   (* Printf.printf "So far so good?\n"; flush stdout; *)
   define_and_run c env evd
 
+let rec last = function
+  | [] -> None
+  | x :: [] -> Some x
+  | _ :: xs -> last xs
+
 let run f args =
   let env = Global.env () in
   let evd = Evd.from_env env in
-  begin match args with
-  | qc_text :: _ ->
+  begin match last args with
+  | Some qc_text ->
     let msg = "QuickChecking " ^ Pp.string_of_ppcmds (Ppconstr.pr_constr_expr env evd qc_text) in
     Feedback.msg_info (Pp.str msg)
-  | _ -> failwith "run called with no arguments"
+  | None -> failwith "run called with no arguments"
   end;
   let args = List.map (fun x -> (x,None)) args in
   let c = CAst.make @@


### PR DESCRIPTION
The `run` command just prints the first argument, which is what we want for `QuickChick prop`, but not for `QuickChickWith arg prop`.