### PR TITLE
Fix extraction of inefficient Nat arithmetic

### DIFF
--- a/src/ExtractionQC.v.cppo
+++ b/src/ExtractionQC.v.cppo
@@ -123,7 +123,6 @@ Extract Constant force => "Lazy.force".
 
 (* Extract Constant Test.ltAscii => "(<=)". *)
 (* Extract Constant Test.strEq   => "(=)". *)
-Extract Constant Nat.div => "(fun m -> function 0 -> 0 | d -> m / d)".
 Extract Constant Test.gte => "(>=)".
 Extract Constant le_gt_dec => "(<=)".
 Extract Constant trace =>
@@ -141,6 +140,15 @@ From mathcomp Require Import ssreflect ssrnat ssrbool div eqtype.
 Extract Constant divn => "(fun m -> function 0 -> 0 | d -> m / d)".
 Extract Constant modn => "(fun m -> function 0 -> m | d -> m mod d)".
 Extract Constant eqn => "(==)".
+
+Extract Constant Nat.add => "(+)".
+Extract Constant Nat.mul => "( * )".
+Extract Constant Nat.sub => "(-)".
+Extract Constant Nat.log2 => "(let rec log2 x = if x <= 1 then 0 else 1 + log2 (x / 2) in log2)".
+Extract Constant Nat.eqb => "(=)".
+Extract Constant Coq.Init.Nat.eqb => "(=)".
+Extract Constant Nat.div => "(fun x -> function 0 -> 0 | y -> x / y)".
+Extract Constant Coq.Init.Nat.div => "(fun x -> function 0 -> 0 | y -> x / y)".
 
 Axiom print_extracted_coq_string : string -> unit.
 Extract Constant print_extracted_coq_string =>


### PR DESCRIPTION
In particular Init.Nat.div (NOT Nat.div from importing Arith!)
led to QuickChick running in time quadratic to the number of test cases.

Init.Nat.div < roundTo < computeSize' < quickCheckWith

Closes #251 