### PR TITLE
Fix for coq PR#13969

### DIFF
--- a/src/GenHighImpl.v
+++ b/src/GenHighImpl.v
@@ -594,7 +594,7 @@ Proof.
 rewrite semBindSize.
 setoid_rewrite semReturnSize.
 rewrite semChooseSize //=.
-setoid_rewrite nthE. (* SLOW *)
+setoid_rewrite nthE.
 case: l => [|x l] /=.
   rewrite (eq_bigcupl [set 0]) ?bigcup_set1 // => n.
   by rewrite leqn0; split=> [/eqP|->].

--- a/src/Sets.v
+++ b/src/Sets.v
@@ -51,6 +51,8 @@ move=> T; constructor=> // [A B eqAB | A B C] x; first by split=> /eqAB.
 exact: set_eq_trans.
 Qed.
 
+#[global] Instance set_eq_rew A : RelationClasses.RewriteRelation (@set_eq A) := {}.
+
 Definition set_incl {A} (m1 m2 : set A) :=
   forall (a : A), m1 a -> m2 a.
 


### PR DESCRIPTION
This should be a backwards compatible fix for Coq PR #13969, making a rewrite go much faster as typeclass resolution no longer searches aimlessly. 