### PR TITLE
quickChickTool: Fix warning

### DIFF
--- a/quickChickTool/quickChickToolParser.mly
+++ b/quickChickTool/quickChickToolParser.mly
@@ -47,7 +47,7 @@ type node =
 %% 
 program:              default_section T_Eof { [$1] }
                     | default_section sections T_Eof { $1 :: $2 }
-                    | error T_Eof { 
+                    | error {
                         let pos = Parsing.symbol_start_pos () in
                         failwith (Printf.sprintf "Error in line %d, position %d" 
                                                  pos.pos_lnum (pos.pos_cnum - pos.pos_bol)) }  


### PR DESCRIPTION
```
File "quickChickTool/quickChickToolParser.mly", line 50, characters 22-33:
Warning: when --strategy simplified is selected,
the error token may appear only at the end of a production
(and the semantic action must abort the parser).
This production will be ignored.
```