### PR TITLE
[coq] Use findlib name in DECLARE PLUGIN

### DIFF
--- a/plugin/tactic_quickchick.mlg.cppo
+++ b/plugin/tactic_quickchick.mlg.cppo
@@ -11,7 +11,7 @@ open Ltac_plugin
 
 }
 
-DECLARE PLUGIN "quickchick_plugin"
+DECLARE PLUGIN "coq-quickchick.plugin"
 
 {
 #if COQ_VERSION >= (8, 15, 0)


### PR DESCRIPTION
After some stronger invariant upstream, the name here has to match the
name used in `Declare ML Module` and `DECLARE PLUGIN`

Backwards compatible.