### PR TITLE
Adapt examples w.r.t. coq/coq#16004.

### DIFF
--- a/examples/DependentTest.v
+++ b/examples/DependentTest.v
@@ -373,6 +373,7 @@ Proof. reflexivity. Qed.
 Inductive goodFooNL : nat -> Foo -> Foo -> Prop :=
 | GoodNL : forall n foo, goodFooNL n (Foo2 foo) foo.
 
+#[global]
 Instance EqDecFoo (f1 f2 : Foo) : Dec (f1 = f2).
 dec_eq. Defined.
 
@@ -406,6 +407,7 @@ Inductive goodBar {A B : Type} (n : nat) : Bar A B -> Prop :=
 Inductive goodFooFalse : Foo -> Prop :=
 | GoodFalse : forall (x : False), goodFooFalse Foo1.
 
+#[global]
 Instance arbFalse : Gen False. Admitted.
 
 Set Warnings "+quickchick-uninstantiated-variables".

--- a/examples/RedBlack/testing.v
+++ b/examples/RedBlack/testing.v
@@ -67,6 +67,7 @@ Fixpoint tree_to_string (t : tree) :=
                             ++ "(" ++ tree_to_string r ++ ")"
   end.
 
+#[global]
 Instance showTree {A : Type} `{_ : Show A} : Show tree :=
   {|
     show t := "" (* CH: tree_to_string t causes a 9x increase in runtime *)

--- a/examples/RedBlack/verif.v
+++ b/examples/RedBlack/verif.v
@@ -71,6 +71,7 @@ Proof.
   move => s. rewrite unsized_alt_def. by apply semColor.
 Qed.
 
+#[global]
 Instance genRBTree_heightMonotonic p :
   SizeMonotonic (genRBTree_height p).
 Proof.
@@ -88,6 +89,7 @@ Proof.
     eapply IH; eauto; (case : x; [ by right | by left; lia]).
 Qed.
 
+#[global]
 Instance genRBTreeMonotonic : SizeMonotonic genRBTree.
 Proof.
   apply bindMonotonic; eauto with typeclass_instances.

--- a/examples/Tutorial.v
+++ b/examples/Tutorial.v
@@ -123,6 +123,7 @@ Inductive Color := Red | Green | Blue | Yellow.
     matching on colors. *)
 
 Require Import String. Open Scope string.
+#[global]
 Instance show_color : Show Color :=
   {| show c :=
        match c with
@@ -315,6 +316,7 @@ Arguments Node {A} _ _ _.
     declaration stems from the fact that Coq's typeclasses (unlike
     Haskell's) are not automatically recursive. *) 
 
+#[global]
 Instance showTree {A} `{_ : Show A} : Show (Tree A) :=
   {| show := 
        let fix aux t :=
@@ -573,9 +575,11 @@ Check sized.
 
     The [shrink] function is simply a shrinker like [shrinkTree]. *)
 
+#[global]
 Instance genTree {A} `{Gen A} : GenSized (Tree A) := 
   {| arbitrarySized n := genTreeSized n arbitrary |}.
 
+#[global]
 Instance shrTree {A} `{Shrink A} : Shrink (Tree A) := 
   {| shrink x := shrinkTree shrink x |}.
 

--- a/examples/ifc-basic/DerivedGen.v
+++ b/examples/ifc-basic/DerivedGen.v
@@ -93,6 +93,7 @@ Definition ainstr (st : State) : G Instruction :=
 Inductive contains_ret : Stack -> Prop := 
   | RetHere  : forall pc s, contains_ret (RetCons pc s)
   | RetLater : forall a  s, contains_ret s -> contains_ret (a :: s).
+#[global]
 Instance dec_contains_ret (s : Stack) : Dec (contains_ret s).
 Proof.
   dec_eq.
@@ -112,6 +113,7 @@ Derive ArbitrarySizedSuchThat for (fun n => stack_length s n).
 
 Inductive between (x y : Z) (z : nat) : Prop :=
 | Bet : (x < y -> y < Z.of_nat z -> between x y z)%Z.
+#[global]
 Instance genST_bet x z : GenSizedSuchThat Z (fun y => between x y z) := 
 {|
   arbitrarySizeST n := liftGen Some (choose (x, Z.of_nat z))

--- a/examples/ifc-basic/Driver.v
+++ b/examples/ifc-basic/Driver.v
@@ -193,6 +193,7 @@ Definition myArgs : Args :=
 
 From QuickChick Require Import Mutate MutateCheck.
 
+#[global]
 Instance mutateable_table : Mutateable table :=
 {|
   mutate := mutate_table

--- a/examples/ifc-basic/GenExec.v
+++ b/examples/ifc-basic/GenExec.v
@@ -108,6 +108,7 @@ Definition gen_state : G State :=
 
 From QuickChick.ifcbasic Require Import Generation.
 
+#[global]
 Instance vary_atom' : Vary Atom :=
 {|
   vary a :=
@@ -118,6 +119,7 @@ Instance vary_atom' : Vary Atom :=
     end
 |}.
 
+#[global]
 Instance vary_mem' : Vary Mem :=
 {|
   vary m := sequenceGen (map vary m)
@@ -136,6 +138,7 @@ Fixpoint vary_stack (s : Stack) (isLow : bool) : G Stack :=
   end.
 
 Import QcDefaultNotation.
+#[global]
 Instance vary_state' : Vary State :=
 {|
   vary st :=

--- a/examples/ifc-basic/Generation.v
+++ b/examples/ifc-basic/Generation.v
@@ -87,6 +87,7 @@ Class Vary (A : Type) := {
   vary : A -> G A
 }.
 
+#[global]
 Instance vary_atom : Vary Atom :=
 {|
   vary a :=
@@ -97,6 +98,7 @@ Instance vary_atom : Vary Atom :=
     end
 |}.
 
+#[global]
 Instance vary_mem : Vary Mem :=
 {|
   vary m := sequenceGen (map vary m)
@@ -114,6 +116,7 @@ Fixpoint vary_stack (s : Stack) (isLow : bool) : G Stack :=
     | Mty => returnGen Mty
   end.
 
+#[global]
 Instance vary_state : Vary State :=
 {|
   vary st :=

--- a/examples/ifc-basic/Indist.v
+++ b/examples/ifc-basic/Indist.v
@@ -17,6 +17,7 @@ Class Indist (A : Type) : Type :=
   indist : A -> A -> bool
 }.
 
+#[global]
 Instance indist_atom : Indist Atom :=
 {|
   indist a1 a2 :=
@@ -29,6 +30,7 @@ Instance indist_atom : Indist Atom :=
     end
 |}.
 
+#[global]
 Instance indist_mem : Indist Mem :=
 {|
   indist m1 m2 := forallb2 indist m1 m2
@@ -43,6 +45,7 @@ Fixpoint cropTop (s:Stack) : Stack :=
   end.
 
 (* Assumes stacks have been cropTopped! *)
+#[global]
 Instance indist_stack : Indist Stack :=
 {|
   indist s1 s2 :=
@@ -56,6 +59,7 @@ Instance indist_stack : Indist Stack :=
     in aux s1 s2
 |}.
 
+#[global]
 Instance indist_state : Indist State :=
 {|
   indist st1 st2 :=

--- a/examples/ifc-basic/Printing.v
+++ b/examples/ifc-basic/Printing.v
@@ -10,6 +10,7 @@ Require Import Coq.Strings.String.
 
 Local Open Scope string.
 
+#[global]
 Instance show_label : Show Label :=
 {|
   show lab :=
@@ -19,6 +20,7 @@ Instance show_label : Show Label :=
     end
 |}.
 
+#[global]
 Instance show_instruction : Show Instruction :=
 {|
   show x :=
@@ -42,6 +44,7 @@ Fixpoint numed_contents {A : Type} (s : A -> string) (l : list A) (n : nat)
 
 Definition par (s : string) := "( " ++ s ++ " )".
 
+#[global]
 Instance show_atom : Show Atom :=
 {|
   show a :=
@@ -49,11 +52,13 @@ Instance show_atom : Show Atom :=
     show v ++ " @ " ++ show l
 |}.
 
+#[global]
 Instance show_list {A : Type} `{_ : Show A} : Show (list A) :=
 {|
   show l := numed_contents show l 0
 |}.
 
+#[global]
 Instance show_stack : Show Stack :=
 {|
   show s :=
@@ -66,6 +71,7 @@ Instance show_stack : Show Stack :=
     in aux s
 |}.
 
+#[global]
 Instance show_state : Show State :=
 {|
   show st :=
@@ -85,6 +91,7 @@ Class ShowPair (A : Type) : Type :=
 Definition show_variation (s1 s2 : string) :=
   "{ " ++ s1 ++ " / " ++ s2 ++ " }".
 
+#[global]
 Instance show_int_pair : ShowPair Z :=
 {|
   show_pair v1 v2 :=
@@ -92,6 +99,7 @@ Instance show_int_pair : ShowPair Z :=
     else show_variation (show v1) (show v2)
 |}.
 
+#[global]
 Instance show_label_pair : ShowPair Label :=
 {|
   show_pair l1 l2 :=
@@ -99,6 +107,7 @@ Instance show_label_pair : ShowPair Label :=
     else show_variation (show l1) (show l2)
 |}.
 
+#[global]
 Instance show_atom_pair : ShowPair Atom :=
 {|
   show_pair a1 a2 :=
@@ -108,6 +117,7 @@ Instance show_atom_pair : ShowPair Atom :=
     ++ show_pair l1 l2
 |}.
 
+#[global]
 Instance show_mem_pair : ShowPair Mem :=
 {|
   show_pair m1 m2 :=
@@ -122,6 +132,7 @@ Fixpoint total_stack_length s :=
     | _ => O
   end.
 
+#[global]
 Instance show_stack_pair : ShowPair Stack :=
 {|
   show_pair s1 s2 :=
@@ -160,6 +171,7 @@ Instance show_stack_pair : ShowPair Stack :=
     in prefix ++ "Common part: " ++ nl ++ aux s1 s2
 |}.
 
+#[global]
 Instance show_state_pair : ShowPair State :=
 {|
   show_pair st1 st2 :=
@@ -171,6 +183,7 @@ Instance show_state_pair : ShowPair State :=
     "PC: " ++ show_pair pc1 pc2 ++ nl
 |}.
 
+#[global]
 Instance show_var {A} `{_ :ShowPair A} : Show (@Variation A) :=
 {|
   show x :=

--- a/examples/stlc/lambda.v
+++ b/examples/stlc/lambda.v
@@ -96,6 +96,7 @@ Inductive typing' (e : env) : term -> type -> Prop :=
       typing' e (App t1 t2) tau2.
 
 Derive Arbitrary for type.
+#[global]
 Instance dec_type (t1 t2 : type) : Dec (t1 = t2).
 Proof. dec_eq. Defined.
 Derive ArbitrarySizedSuchThat for (fun x => bind env x tau).
@@ -345,6 +346,7 @@ Fixpoint show_type (tau : type) :=
       "(" ++ show_type tau1 ++ " -> " ++ show_type tau2 ++ ")"
   end.
 
+#[global]
 Instance showType : Show type := { show := show_type }.
 
 Fixpoint show_term (t : term) :=
@@ -357,4 +359,5 @@ Fixpoint show_term (t : term) :=
 
 Close Scope string.
 
+#[global]
 Instance showTerm : Show term := { show := show_term }.

--- a/examples/stlc/monad.v
+++ b/examples/stlc/monad.v
@@ -25,6 +25,7 @@ Definition liftM2 {M : Type -> Type} `{monad M} {A1 A2 B : Type} (f : A1 -> A2 -
   n2 <- m2 ;;
   ret (f n1 n2).
 
+#[global]
 Instance optionMonad : monad option :=
   {
     ret A x := Some x;
@@ -38,6 +39,7 @@ Instance optionMonad : monad option :=
 
 Definition State (St : Type) (A: Type) := St -> (A * St)%type.
 
+#[global]
 Instance stateMonad {St : Type} : monad (State St) :=
   {
     ret A x := fun s => (x, s);


### PR DESCRIPTION
The `examples` folder was forgotten in #291.