### PR TITLE
Adapt to coq/coq#16920

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,12 +114,6 @@ workflows:
   build:
     jobs:
       - dune:
-          name: Dune 8.11
-          coq: '8.11'
-      - dune:
-          name: Dune 8.12
-          coq: '8.12'
-      - dune:
           name: Dune 8.13
           coq: '8.13'
       - dune:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,14 @@ workflows:
           name: Dune 8.14
           coq: '8.14'
       - dune:
-          name: Dune latest
-          coq: latest
+          name: Dune 8.15
+          coq: '8.15'
+      - dune:
+          name: Dune 8.16
+          coq: '8.16'
+      - dune:
+          name: Dune 8.17
+          coq: '8.17'
       - opam:
           name: OPAM dev
           coq: dev

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ tests:
 #	coqc examples/BSTTest.v
 	coqc examples/DependentTest.v
 
-COMPATFILES:=plugin/depDriver.ml plugin/driver.mlg plugin/genericLib.ml plugin/quickChick.mlg plugin/tactic_quickchick.mlg plugin/weightmap.mlg src/ExtractionQC.v src/QuickChick.v _CoqProject
+COMPATFILES:=plugin/depDriver.ml plugin/genericLib.ml plugin/quickChick.mlg plugin/tactic_quickchick.mlg plugin/weightmap.mlg src/ExtractionQC.v src/QuickChick.v _CoqProject
 
 compat: $(COMPATFILES)
 

--- a/dune-project
+++ b/dune-project
@@ -33,7 +33,7 @@
   (ocaml (>= 4.07))
   (menhir :build)
   (cppo (and :build (>= 1.6.8)))
-  (coq (>= 8.11~))
+  (coq (>= 8.13~))
   coq-ext-lib
   coq-mathcomp-ssreflect
   coq-simple-io

--- a/plugin/driver.mlg
+++ b/plugin/driver.mlg
@@ -1,12 +1,4 @@
 {
-
-(*
-
-THIS FILE IS PREPROCESSED USING cppo
-MAKE SURE TO EDIT THE .cppo SOURCE OF THIS FILE RATHER THAN THE GENERATED RESULT
-
-*)
-
 open Libnames
 open Util
 open Constrexpr
@@ -52,11 +44,7 @@ let dispatch cn ind name1 name2 =
     | {CAst.v = CRef (r, _) ; _} -> string_of_qualid r
     | _ -> failwith "Usage: Derive <class_name> for <inductive_name> OR  Derive (<class_name>, ... , <class_name>) for <inductive_name>" in
   let ss = match cn.CAst.v with
-#if COQ_VERSION >= (8, 12, 0)
      | CNotation (_, _, ([a],[b],_,_)) ->
-#else
-     | CNotation (_, ([a],[b],_,_)) ->
-#endif
          let c = convert_reference_to_string a in
          let cs = List.map convert_reference_to_string b in
          c :: cs

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -94,11 +94,7 @@ let gArg ?assumName:(an=hole) ?assumType:(at=hole) ?assumImplicit:(ai=false) ?as
     | { CAst.v = CRef (qid, _); loc } -> (loc,Name (qualid_basename qid))
     | { CAst.v = CHole _; loc } -> (loc,Anonymous)
     | _a -> failwith "This expression should be a name" in
-#if COQ_VERSION >= (8, 12, 0)
   let max_implicit = Glob_term.MaxImplicit in
-#else
-  let max_implicit = Glob_term.Implicit in
-#endif
   CLocalAssum ( [CAst.make ?loc:(fst n) @@ snd n],
                   (if ag then Generalized (max_implicit, false)
                    else if ai then Default max_implicit else Default Glob_term.Explicit),
@@ -872,14 +868,7 @@ let dtTupleType =
 let nat_scope ast = CAst.make @@ CDelimiters ("nat", ast)
 let gInt n =
   let number =
-#if COQ_VERSION >= (8, 13, 0)
     Number (NumTok.Signed.of_int_string (string_of_int n))
-#elif COQ_VERSION >= (8, 12, 0)
-    Numeral (NumTok.Signed.of_int_string (string_of_int n))
-#else
-    if n >= 0 then Numeral (SPlus, NumTok.int (string_of_int n))
-    else Numeral (SMinus, NumTok.int (string_of_int (-n)))
-#endif
   in nat_scope (CAst.make @@ CPrim number)
 let gSucc x = gApp (gInject "Coq.Init.Datatypes.S") [x]
 let rec maximum = function

--- a/plugin/tactic_quickchick.mlg.cppo
+++ b/plugin/tactic_quickchick.mlg.cppo
@@ -36,10 +36,8 @@ let quickchick_goal =
     (* Externalize it *)
 #if COQ_VERSION >= (8, 17, 0)
     let ct = Constrextern.extern_constr e evd (EConstr.mkEvar (evar, SList.empty)) in
-#elif COQ_VERSION >= (8, 12, 0)
-    let ct = Constrextern.extern_constr e evd (EConstr.mkEvar (evar, [])) in
 #else
-    let ct = Constrextern.extern_constr false e evd (EConstr.mkEvar (evar, [||])) in
+    let ct = Constrextern.extern_constr e evd (EConstr.mkEvar (evar, [])) in
 #endif
 
     (* Construct : show (quickCheck (_ : ct)) *)

--- a/plugin/weightmap.mlg.cppo
+++ b/plugin/weightmap.mlg.cppo
@@ -39,21 +39,11 @@ let register_weights (l : (constructor * weight_ast) list) =
 
 let convert_constr_to_weight c = 
   match c.CAst.v with
-#if COQ_VERSION >= (8, 12, 0)
-#if COQ_VERSION >= (8, 13, 0)
   | CPrim (Number (NumTok.SPlus, i)) ->
-#else
-  | CPrim (Numeral (NumTok.SPlus, i)) ->
-#endif
       (match NumTok.Unsigned.to_nat i with
       | Some n -> WNum (int_of_string n)
       | None -> failwith "QC: Numeric weights should be positive integers."
       )
-#else
-
-  | CPrim (Constrexpr.Numeral (Constrexpr.SPlus, NumTok.{int=n;frac="";exp=""})) ->
-      WNum (int_of_string n)
-#endif
   | CRef (r, _) ->
      if string_of_qualid r = "size" then WSize
      else failwith "QC: Expected number or 'size'."
@@ -61,11 +51,7 @@ let convert_constr_to_weight c =
 
 let convert_constr_to_cw_pair c : (constructor * weight_ast) = 
   match c.CAst.v with
-#if COQ_VERSION >= (8, 12, 0)
   | CNotation (_, _, ([a],[[b]],_,_)) ->
-#else
-  | CNotation (_, ([a],[[b]],_,_)) ->
-#endif
       let ctr = 
         match a with 
         | { CAst.v = CRef (r, _); _ } -> injectCtr (string_of_qualid r)
@@ -105,11 +91,7 @@ VERNAC COMMAND EXTEND QuickChickWeights CLASSIFIED AS SIDEFF
      {
        let weight_assocs = 
          match c.CAst.v with
-#if COQ_VERSION >= (8, 12, 0)
          | CNotation (_, _, ([a],[b],_,_)) ->
-#else
-         | CNotation (_, ([a],[b],_,_)) ->
-#endif
              let c = convert_constr_to_cw_pair a in
              let cs = List.map convert_constr_to_cw_pair b in
              c :: cs

--- a/src/ExtractionQC.v.cppo
+++ b/src/ExtractionQC.v.cppo
@@ -88,7 +88,11 @@ Extract Constant randomNext   => "(fun r -> Random.State.bits r, r)".
 Extract Constant randomSplit  => "(fun x -> (x,x))".
 Extract Constant mkRandomSeed => "(fun x -> Random.init x; Random.get_state())".
 Extract Constant randomRNat  =>
+#if OCAML_VERSION >= (4, 13, 0)
   "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.full_int r (y - x + 1)), r))".
+#else
+  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.int r (y - x + 1)), r))".
+#endif
 Extract Constant randomRBool => "(fun _ r -> Random.State.bool r, r)".
 Extract Constant randomRInt  =>
 #if COQ_VERSION >= (8, 15, 0)
@@ -99,8 +103,10 @@ Extract Constant randomRInt  =>
     let range_Z = Big_int_Z.succ_big_int (Big_int_Z.sub_big_int y x) in
     let range_int = Big_int_Z.int_of_big_int range_Z in
     (Big_int_Z.add_big_int x (Big_int_Z.big_int_of_int (Random.State.int r range_int)), r))".
-#else
+#elif OCAML_VERSION >= (4, 13, 0)
   "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.full_int r (y - x + 1)), r))".
+#else
+  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.int r (y - x + 1)), r))".
 #endif
 Extract Constant randomRN =>
 #if COQ_VERSION >= (8, 15, 0)
@@ -111,8 +117,10 @@ Extract Constant randomRN =>
     let range_Z = Big_int_Z.succ_big_int (Big_int_Z.sub_big_int y x) in
     let range_int = Big_int_Z.int_of_big_int range_Z in
     (Big_int_Z.add_big_int x (Big_int_Z.big_int_of_int (Random.State.int r range_int)), r))".
-#else
+#elif OCAML_VERSION >= (4, 13, 0)
   "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.full_int r (y - x + 1)), r))".
+#else
+  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.int r (y - x + 1)), r))".
 #endif
 Extract Constant newRandomSeed => "(Random.State.make_self_init ())".
 

--- a/src/ExtractionQC.v.cppo
+++ b/src/ExtractionQC.v.cppo
@@ -25,23 +25,14 @@ Require Import ExtrOcamlZInt.
 
 Extraction Blacklist String List Nat.
 
-#if COQ_VERSION >= (8, 12, 0)
-#if COQ_VERSION >= (8, 13, 0)
-#define Number_int Number.int
-#else
-#define Number_int Numeral.int
-#endif
 Extract Inductive Hexadecimal.int => "((Obj.t -> Obj.t) -> (Obj.t -> Obj.t) -> Obj.t) (* Hexadecimal.int *)"
   [ "(fun x pos _ -> pos (Obj.magic x))"
     "(fun y _ neg -> neg (Obj.magic y))"
   ] "(fun i pos neg -> Obj.magic i pos neg)".
-Extract Inductive Number_int => "((Obj.t -> Obj.t) -> (Obj.t -> Obj.t) -> Obj.t) (* Number_int *)"
+Extract Inductive Number.int => "((Obj.t -> Obj.t) -> (Obj.t -> Obj.t) -> Obj.t) (* Number.int *)"
   [ "(fun x dec _ -> dec (Obj.magic x))"
     "(fun y _ hex -> hex (Obj.magic y))"
   ] "(fun i dec hex -> Obj.magic i dec hex)".
-#else
-(* Hexadecimal.int and Numeral.int don't exist before 8.12 *)
-#endif
 
 (** Temporary fix for https://github.com/coq/coq/issues/7017. *)
 (** Scott encoding of [Decimal.int] as [forall r. (uint -> r) -> (uint -> r) -> r]. *)
@@ -97,11 +88,7 @@ Extract Constant randomNext   => "(fun r -> Random.State.bits r, r)".
 Extract Constant randomSplit  => "(fun x -> (x,x))".
 Extract Constant mkRandomSeed => "(fun x -> Random.init x; Random.get_state())".
 Extract Constant randomRNat  =>
-#if OCAML_VERSION >= (4, 13, 0)
   "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.full_int r (y - x + 1)), r))".
-#else
-  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.int r (y - x + 1)), r))".
-#endif
 Extract Constant randomRBool => "(fun _ r -> Random.State.bool r, r)".
 Extract Constant randomRInt  =>
 #if COQ_VERSION >= (8, 15, 0)
@@ -112,10 +99,8 @@ Extract Constant randomRInt  =>
     let range_Z = Big_int_Z.succ_big_int (Big_int_Z.sub_big_int y x) in
     let range_int = Big_int_Z.int_of_big_int range_Z in
     (Big_int_Z.add_big_int x (Big_int_Z.big_int_of_int (Random.State.int r range_int)), r))".
-#elif OCAML_VERSION >= (4, 13, 0)
-  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.full_int r (y - x + 1)), r))".
 #else
-  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.int r (y - x + 1)), r))".
+  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.full_int r (y - x + 1)), r))".
 #endif
 Extract Constant randomRN =>
 #if COQ_VERSION >= (8, 15, 0)
@@ -126,10 +111,8 @@ Extract Constant randomRN =>
     let range_Z = Big_int_Z.succ_big_int (Big_int_Z.sub_big_int y x) in
     let range_int = Big_int_Z.int_of_big_int range_Z in
     (Big_int_Z.add_big_int x (Big_int_Z.big_int_of_int (Random.State.int r range_int)), r))".
-#elif OCAML_VERSION >= (4, 13, 0)
-  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.full_int r (y - x + 1)), r))".
 #else
-  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.int r (y - x + 1)), r))".
+  "(fun (x,y) r -> if y < x then failwith ""choose called with unordered arguments"" else  (x + (Random.State.full_int r (y - x + 1)), r))".
 #endif
 Extract Constant newRandomSeed => "(Random.State.make_self_init ())".
 

--- a/src/GenLow.v
+++ b/src/GenLow.v
@@ -234,7 +234,7 @@ Module GenLow : GenLowInterface.Sig.
   (* end semBindSize *)
   Proof.
     rewrite /semGenSize /bindGen /= bigcup_codom -curry_codom2l.
-      by rewrite -[codom (prod_curry _)]imsetT -randomSplit_codom -codom_comp.
+      by rewrite -[codom (uncurry _)]imsetT -randomSplit_codom -codom_comp.
   Qed.
   
   Lemma semBindSize_subset_compat {A B : Type} (g g' : G A) (f f' : A -> G B) :

--- a/src/Sets.v
+++ b/src/Sets.v
@@ -95,9 +95,9 @@ Definition imset {T U} (f : T -> U) A := bigcup A (fun x => set1 (f x)).
 Definition setX T U (A : set T) (B : set U) := [set x | x.1 \in A /\ x.2 \in B].
 
 Definition imset2 T U V (f : T -> U -> V) A1 A2 :=
-  imset (prod_curry f) (setX A1 A2).
+  imset (uncurry f) (setX A1 A2).
 
-Definition codom2 T U V (f : T -> U -> V) := codom (prod_curry f).
+Definition codom2 T U V (f : T -> U -> V) := codom (uncurry f).
 
 Notation "[ 'set' a ]" := (set1 a)
   (at level 0, a at level 99, format "[ 'set'  a ]") : set_scope.
@@ -372,7 +372,7 @@ Lemma curry_imset2r T U V (f : T -> U -> V) A1 A2 :
 Proof. by rewrite curry_imset2l bigcupC. Qed.
 
 Lemma curry_codom2l T U V (f : T -> U -> V) :
-  codom (prod_curry f) <--> \bigcup_x1 codom (f x1).
+  codom (uncurry f) <--> \bigcup_x1 codom (f x1).
 Proof.
 rewrite -imsetT -setXT -/(imset2 f _ _) curry_imset2l.
 by apply: eq_bigcupr => x; rewrite imsetT.


### PR DESCRIPTION
Use `uncurry` instead of deprecated `prod_curry` (coq/coq#16920).