### PR TITLE
Dec derivining mutind bugfix

### DIFF
--- a/plugin/genericLib.ml
+++ b/plugin/genericLib.ml
@@ -321,7 +321,7 @@ let parse_constructors nparams param_names result_ty oib : ctr_rep list option =
         end 
       end
       else if isInd ty then begin
-        let ((mind,_),_) = destInd ty in
+        let ((mind, mindidx),_) = destInd ty in
         Some (TyCtr (qualid_of_ident (Label.to_id (MutInd.label mind)), []))
       end
       else if isConst ty then begin
@@ -439,10 +439,14 @@ let parse_dependent_type i nparams ty oib arg_names =
       | None -> CErrors.user_err (str "Aux failed?" ++ fnl ())
     end
     else if isInd ty then begin
-      let ((mind,_),_) = destInd ty in
+      let ((mind, midx),_) = destInd ty in
+      let mib = Environ.lookup_mind mind env in
+      let id = mib.mind_packets.(midx).mind_typename in
+      (*
       msg_debug (str (Printf.sprintf "LOOK HERE: %s - %s - %s" (MutInd.to_string mind) (Label.to_string (MutInd.label mind)) 
                                                             (Id.to_string (Label.to_id (MutInd.label mind)))) ++ fnl ());
-      Some (DTyCtr (qualid_of_ident (Label.to_id (MutInd.label mind)), []))
+                                                            *)
+      Some (DTyCtr (qualid_of_ident id, []))
     end
     else if isConstruct ty then begin
       let (((mind, midx), idx),_) = destConstruct ty in                               

--- a/plugin/genericLib.ml
+++ b/plugin/genericLib.ml
@@ -321,8 +321,11 @@ let parse_constructors nparams param_names result_ty oib : ctr_rep list option =
         end 
       end
       else if isInd ty then begin
-        let ((mind, mindidx),_) = destInd ty in
-        Some (TyCtr (qualid_of_ident (Label.to_id (MutInd.label mind)), []))
+        let ((mind, midx),_) = destInd ty in
+        let env = Global.env () in
+        let mib = Environ.lookup_mind mind env in
+        let id = mib.mind_packets.(midx).mind_typename in
+        Some (TyCtr (qualid_of_ident id, []))
       end
       else if isConst ty then begin
         let (c,_) = destConst ty in 
@@ -442,10 +445,8 @@ let parse_dependent_type i nparams ty oib arg_names =
       let ((mind, midx),_) = destInd ty in
       let mib = Environ.lookup_mind mind env in
       let id = mib.mind_packets.(midx).mind_typename in
-      (*
-      msg_debug (str (Printf.sprintf "LOOK HERE: %s - %s - %s" (MutInd.to_string mind) (Label.to_string (MutInd.label mind)) 
-                                                            (Id.to_string (Label.to_id (MutInd.label mind)))) ++ fnl ());
-                                                            *)
+      (* msg_debug (str (Printf.sprintf "LOOK HERE: %s - %s - %s" (MutInd.to_string mind) (Label.to_string (MutInd.label mind)) 
+                                                            (Id.to_string (Label.to_id (MutInd.label mind)))) ++ fnl ());*)
       Some (DTyCtr (qualid_of_ident id, []))
     end
     else if isConstruct ty then begin


### PR DESCRIPTION
The current implementation for deriving ```DecOpt``` instances does not work correctly for (non-mutually) inductive relations over mutually inductive datatypes.

A brief example):
```Coq
Inductive Test1 : Type :=
  | T1 : Test1
with Test2 :=
  | T2 : Test2.

Inductive Test2_Prop : Test2 -> Prop :=
  | T2P : Test2_Prop T2.

QCDerive DecOpt for (Test2_Prop t2).
```
This example is not very representative, but the bug/error still arises.

The computation derived in this example will be over an argument of the type `Test1`, whilst the correct type for `t2` in the above example is `Test2`. The implementation as of now disregards that mutually inductive datatypes are essentially multiple definitions, and simply always considers the first definitions which is the type `Test1` in the example.

My solution is more or less a copy from how constructors are handle, where an inductive relation can have multiple constructors, so the right one has to be targeted by means of an index. I applied the same idea for mutually inductive datatype definitions, and target the right one using an index. Then, the derivation of the `DecOpt` instance in the example, will have an argument with the type `Test2` instead, and Coq will stop complaining because this computation now passes the type-check.
