### PR TITLE
Tutorial: mention output location within VS Code's VSCoq plugin

### DIFF
--- a/examples/Tutorial.v
+++ b/examples/Tutorial.v
@@ -56,12 +56,13 @@ Definition removeP (x : nat) (l : list nat) :=
 
 QuickChick removeP.
 
-(** Internally, the code is extracted to OCaml, compiled and ran to
-obtain the output:
+(** Internally, the code is extracted to OCaml, compiled, and run.  The
+following output is presented in your terminal, CoqIDE [Messages] pane, or
+Visual Studio Code [Info] pulldown menu tab:
 <<
     0
 
-    [ 0, 0 ]
+    [0; 0]
 
     Failed! After 17 tests and 12 shrinks
 >>


### PR DESCRIPTION
Per #267, VSCoq places QuickChick output in a non-obvious location, so it appears as though `QuickChick` is a no-op unless you know exactly where to look.  While this could be documented in the README or some other top-level document, I think having it front-and-centre in the tutorial is optimal as I imagine that's the location where newcomers are most likely to trip over things.  (This was my situation this afternoon, for instance.)  I do concede that it breaks the flow of the tutorial a bit, though, so not opposed to the alternative.