### PR TITLE
Don't build documentation during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ documentation-check: plugin
 
 TEMPFILE := $(shell mktemp)
 
-install: all
+install: quickChickTool plugin
 	$(V)$(MAKE) -f Makefile.coq install > $(TEMPFILE)
 # Manually copying the remaining files
 	$(V)cp $(QCTOOL_DIR)/$(QCTOOL_EXE) $(INSTALLDIR)/quickChick


### PR DESCRIPTION
`make documentation-check` doesn't cache the output of the `coqc` invocations and hence those invocations are re-run every time this target is run (unclear to me if this is intentional).

This also happens during `make install`, which means that non-installation related things are happening inside of opam during installation.