### PR TITLE
`etna:README.md`: fix `opam install . --deps-only`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Dependencies are listed in [`coq-quickchick.opam`](./coq-quickchick.opam).
     # To get the dependencies, add the Coq opam repository if you haven't already
     opam repo add coq-released https://coq.inria.fr/opam/released
     opam update
-    opam install --deps-only
+    opam install . --deps-only
 
 #### Build using Make
 


### PR DESCRIPTION
Ran into this while going through the artifact instructions at https://github.com/jwshi21/etna