### PR TITLE
Fix for deriving DecOpt when index of inductive is from an inductive family

### DIFF
--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -356,8 +356,11 @@ let parse_constructors nparams param_names result_ty oib : ctr_rep list option =
         end 
       end
       else if isInd ty then begin
-        let ((mind,_),_) = destInd ty in
-        Some (TyCtr (qualid_of_ident (Label.to_id (MutInd.label mind)), []))
+        let ((mind, midx),_) = destInd ty in
+        let env = Global.env () in
+        let mib = Environ.lookup_mind mind env in
+        let id = mib.mind_packets.(midx).mind_typename in
+        Some (TyCtr (qualid_of_ident id, []))
       end
       else if isConst ty then begin
         let (c,_) = destConst ty in 
@@ -478,10 +481,12 @@ let parse_dependent_type_internal i nparams ty oibopt arg_names =
       | None -> CErrors.user_err (str "Aux failed?" ++ fnl ())
     end
     else if isInd ty then begin
-      let ((mind,_),_) = destInd ty in
-      msg_debug (str (Printf.sprintf "LOOK HERE: %s - %s - %s" (MutInd.to_string mind) (Label.to_string (MutInd.label mind)) 
-                                                            (Id.to_string (Label.to_id (MutInd.label mind)))) ++ fnl ());
-      Some (DTyCtr (qualid_of_ident (Label.to_id (MutInd.label mind)), []))
+      let ((mind, midx),_) = destInd ty in
+      let mib = Environ.lookup_mind mind env in
+      let id = mib.mind_packets.(midx).mind_typename in
+      (* msg_debug (str (Printf.sprintf "LOOK HERE: %s - %s - %s" (MutInd.to_string mind) (Label.to_string (MutInd.label mind)) 
+                                                            (Id.to_string (Label.to_id (MutInd.label mind)))) ++ fnl ());*)
+      Some (DTyCtr (qualid_of_ident id, []))
     end
     else if isConstruct ty then begin
       let (((mind, midx), idx),_) = destConstruct ty in                               


### PR DESCRIPTION
This is the same fix as in https://github.com/QuickChick/QuickChick/pull/314 but applied on `master` (and I squashed the two commits that introduced changes). Please see that PR for more details.