### PR TITLE
Basic quickchick tactic for use during proofs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ tests:
 #	$(MAKE) -C examples/c-mutation test
 #	coqc examples/BSTTest.v
 	coqc examples/DependentTest.v
+	coqc examples/TacticExample.v
 
 COMPATFILES:= \
 	plugin/depDriver.ml \

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -2,7 +2,13 @@ Set Warnings "-extraction-opaque-accessed,-extraction".
 Set Warnings "-notation-overridden,-parsing".
 
 From QuickChick Require Import QuickChick.
+Definition to_be_generated :=
+  forAll arbitrary (fun x =>
+  forAll arbitrary (fun y =>                      
+  if (x = y)? then checker ((x = 0)?)
+  else checker tt)).
 
+QuickChickDebug Debug On.
 Theorem foo : forall (x y: nat) , x = y -> x = 0.
 Proof.
   quickchick.

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -2,14 +2,633 @@ Set Warnings "-extraction-opaque-accessed,-extraction".
 Set Warnings "-notation-overridden,-parsing".
 
 From QuickChick Require Import QuickChick.
+From Coq Require Import Nat.
+From Coq Require Import Arith.Arith.
+(*From Coq Require Import Bool.Bool.*)
+(*Require Export Coq.Strings.String.*)
+From Coq Require Import Logic.FunctionalExtensionality.
+(*From Coq Require Import Lists.List.*)
+(*Import ListNotations.*)
+Set Default Goal Selector "!".
+
 Definition to_be_generated :=
   forAll arbitrary (fun x =>
   forAll arbitrary (fun y =>                      
   if (x = y)? then checker ((x = 0)?)
   else checker tt)).
 
+
+Inductive evenP : nat -> Prop :=
+| even0 : evenP 0
+| evenSS : forall n, evenP n -> evenP (S (S n)).
+
+(*Create a DecOpt instance for even*)
+#[global] 
+Instance even_dec_opt (n :nat ) : DecOpt (evenP n) :=
+  { decOpt := fun _ => Some (Nat.even n) }.
+
+
 QuickChickDebug Debug On.
-Theorem foo : forall (x y: nat) , x = y -> x <> 0.
+Theorem foo : forall (x y : nat) , x < 8.
+Proof.
+  quickchick.
+Admitted.
+
+Theorem add_0_r_firsttry : forall n:nat,
+    n + 0 = n.
 Proof.
   quickchick.
 Abort.
+
+Theorem minus_n_n : forall n,
+  minus n n = 0.
+Proof.
+  quickchick.
+Abort.
+
+Theorem mul_0_r : forall n:nat,
+  n * 0 = 0.
+Proof.
+  quickchick.
+Abort.
+
+
+Theorem mul_0_r : forall n:nat,
+  n * 0 = 0.
+Proof.
+  quickchick.  Admitted.
+
+Theorem plus_n_Sm : forall n m : nat,
+  S (n + m) = n + (S m).
+Proof.
+  quickchick.  Admitted.
+
+Theorem add_comm : forall n m : nat,
+  n + m = m + n.
+Proof.
+  quickchick.  Admitted.
+
+Theorem add_assoc : forall n m p : nat,
+  n + (m + p) = (n + m) + p.
+Proof.
+  quickchick.  Admitted.
+
+
+Fixpoint double (n:nat) :=
+  match n with
+  | O => O
+  | S n' => S (S (double n'))
+  end.
+
+(** Use induction to prove this simple fact about [double]: *)
+Local Open Scope nat_scope.
+Lemma double_plus : forall n, double n = n + n .
+Proof.
+  quickchick.  Admitted.
+
+Fixpoint nateqb (n m : nat) :=
+  match n,m with
+  | 0, 0 => true
+  | S n, S m => nateqb n m
+  | _, _ => false
+  end.
+
+Theorem eqb_refl : forall n : nat,
+  nateqb n n = true.
+Proof. quickchick. Admitted.
+
+Theorem even_S : forall n : nat,
+  even (S n) = negb (even n).
+Proof. quickchick. Admitted.
+
+(* ################################################################# *)
+
+Theorem mult_0_plus' : forall n m : nat,
+  (n + 0 + 0) * m = n * m.
+Proof. quickchick. Admitted.
+
+Theorem plus_rearrange_firsttry : forall n m p q : nat,
+  (n + m) + (p + q) = (m + n) + (p + q).
+Proof. quickchick. Admitted.
+Theorem plus_rearrange : forall n m p q : nat,
+  (n + m) + (p + q) = (m + n) + (p + q).
+Proof. quickchick. Admitted.
+(* ################################################################# *)
+
+
+Theorem add_assoc' : forall n m p : nat,
+  n + (m + p) = (n + m) + p.
+Proof. quickchick. Admitted.
+Theorem add_assoc'' : forall n m p : nat,
+  n + (m + p) = (n + m) + p.
+Proof. quickchick. Admitted.
+
+
+
+(* Do not modify the following line: *)
+Definition manual_grade_for_add_comm_informal : option (nat*string) := None.
+
+(* Do not modify the following line: *)
+Definition manual_grade_for_eqb_refl_informal : option (nat*string) := None.
+(* ################################################################# *)
+
+Theorem add_shuffle3 : forall n m p : nat,
+  n + (m + p) = m + (n + p).
+Proof. quickchick. Admitted.
+Theorem mul_comm : forall m n : nat,
+  m * n = n * m.
+Proof. quickchick. Admitted.
+
+Search (nat -> nat -> bool).
+Theorem plus_leb_compat_l : forall (n m p : nat),
+  (Nat.leb n m = true) -> (((p + n) <=? (p + m)) = true).
+Proof. quickchick. Admitted.
+
+Theorem leb_refl : forall n:nat,
+  (n <=? n) = true.
+Proof. quickchick. Admitted.
+Theorem zero_neqb_S : forall n:nat,
+  0 =? (S n) = false.
+Proof. quickchick. Admitted.
+Theorem andb_false_r : forall b : bool,
+  andb b false = false.
+Proof. quickchick. Admitted.
+Theorem S_neqb_0 : forall n:nat,
+  (S n) =? 0 = false.
+Proof. quickchick. Admitted.
+Theorem mult_1_l : forall n:nat, 1 * n = n.
+Proof. quickchick. Admitted.
+Theorem all3_spec : forall b c : bool,
+  orb
+    (andb b c)
+    (orb (negb b)
+         (negb c))
+  = true.
+Proof. quickchick. Admitted.
+Theorem mult_plus_distr_r : forall n m p : nat,
+  (n + m) * p = (n * p) + (m * p).
+Proof. quickchick. Admitted.
+Theorem mult_assoc : forall n m p : nat,
+  n * (m * p) = (n * m) * p.
+Proof. quickchick. Admitted.
+
+Theorem add_shuffle3' : forall n m p : nat,
+  n + (m + p) = m + (n + p).
+Proof. quickchick. Admitted.
+(* ################################################################# *)
+
+Inductive bin : Type :=
+  | Z
+  | B0 (n : bin)
+  | B1 (n : bin)
+.
+
+Derive (Arbitrary, Show) for bin.
+
+Fixpoint bineq (n m : bin) : bool :=
+  match n, m with
+  | Z, Z => true
+  | B0 n, B0 m => bineq n m
+  | B1 n, B1 m => bineq n m
+  | _,_ => false
+  end.
+
+Fixpoint incr (m:bin) : bin :=
+  match m with
+  | Z => B1 Z
+  | B0 m' => B1 m'
+  | B1 m' => B0 (incr m')
+  end.
+
+Fixpoint bin_to_nat (m:bin) : nat :=
+  match m with
+  | Z => O
+  | B0 m' => double (bin_to_nat m')
+  | B1 m' => S (double (bin_to_nat m'))
+  end.
+
+Theorem bin_to_nat_pres_incr : forall b : bin,
+  bin_to_nat (incr b) = 1 + bin_to_nat b.
+Proof. quickchick. Admitted.
+
+Fixpoint nat_to_bin (n:nat) : bin :=
+  match n with
+  | O => Z
+  | S n' => incr (nat_to_bin n')
+  end.
+
+Theorem nat_bin_nat : forall n, bin_to_nat (nat_to_bin n) = n.
+Proof. quickchick. Admitted.
+(* ################################################################# *)
+
+
+
+#[global] 
+Instance bineq_dec_opt (b b' : bin ) : DecOpt (b = b') :=
+  { decOpt := fun _ => Some (bineq b b') }.
+
+
+Theorem bin_nat_bin_fails : forall b, nat_to_bin (bin_to_nat b) = b.
+Proof. quickchick. Abort.
+
+Lemma double_incr : forall n : nat, double (S n) = S (S (double n)).
+Proof. quickchick. Admitted.
+Definition double_bin (b:bin) : bin :=
+  match b with
+  | Z => Z
+  | B0 b' => B0 (B0 b')
+  | B1 b' => B0 (B1 b')
+  end.
+
+Example double_bin_zero : double_bin Z = Z.
+Proof. quickchick. Admitted.
+
+
+Lemma double_incr_bin : forall b,
+    double_bin (incr b) = incr (incr (double_bin b)).
+Proof. quickchick. Admitted.
+
+
+Fixpoint normalize (b:bin) : bin :=
+  match b with
+  | Z => Z
+  | B0 b' => match normalize b' with
+             | Z => Z
+             | b'' => B0 b''
+             end
+  | B1 b' => B1 (normalize b')
+  end.
+(* FILL IN HERE *)
+Theorem bin_nat_bin : forall b, nat_to_bin (bin_to_nat b) = normalize b.
+Proof. quickchick. Admitted.
+
+Module NatList.
+
+Inductive natprod : Type :=
+  | pair (n1 n2 : nat).
+Derive (Arbitrary, Show) for natprod.
+#[global] Instance Dec_eq_natprod (n n' : natprod) : Dec (n = n').
+Proof. dec_eq. Defined.
+Check (pair 3 5) : natprod.
+Definition fst (p : natprod) : nat :=
+  match p with
+  | pair x y => x
+  end.
+Definition snd (p : natprod) : nat :=
+  match p with
+  | pair x y => y
+  end.
+Notation "( x , y )" := (pair x y).
+Definition fst' (p : natprod) : nat :=
+  match p with
+  | (x,y) => x
+  end.
+Definition snd' (p : natprod) : nat :=
+  match p with
+  | (x,y) => y
+  end.
+Definition swap_pair (p : natprod) : natprod :=
+  match p with
+  | (x,y) => (y,x)
+  end.
+        
+Theorem surjective_pairing' : forall (n m : nat),
+  (n,m) = (fst (n,m), snd (n,m)).
+Proof. quickchick. Admitted.
+Theorem surjective_pairing_stuck : forall (p : natprod),
+  p = (fst p, snd p).
+Proof. quickchick. Admitted.
+Theorem surjective_pairing : forall (p : natprod),
+  p = (fst p, snd p).
+Proof. quickchick. Admitted.
+Theorem snd_fst_is_swap : forall (p : natprod),
+  (snd p, fst p) = swap_pair p.
+Proof. quickchick. Admitted.
+Theorem fst_swap_is_snd : forall (p : natprod),
+  fst (swap_pair p) = snd p.
+Proof. quickchick. Admitted.
+
+Inductive natlist : Type :=
+  | nil
+  | cons (n : nat) (l : natlist).
+
+Derive Show for natlist.
+Derive Arbitrary for natlist.
+#[global] Instance Dec_eq_natlist (l l' : natlist) : Dec (l = l').
+Proof. dec_eq. Defined.
+
+Definition mylist := cons 1 (cons 2 (cons 3 nil)).
+Notation "x :: l" := (cons x l)
+                     (at level 60, right associativity).
+Notation "[ ]" := nil.
+Notation "[ x ; .. ; y ]" := (cons x .. (cons y nil) ..).
+Definition mylist1 := 1 :: (2 :: (3 :: nil)).
+Definition mylist2 := 1 :: 2 :: 3 :: nil.
+Definition mylist3 := [1;2;3].
+
+Fixpoint repeat (n count : nat) : natlist :=
+  match count with
+  | O => nil
+  | S count' => n :: (repeat n count')
+  end.
+
+Fixpoint length (l:natlist) : nat :=
+  match l with
+  | nil => O
+  | h :: t => S (length t)
+  end.
+
+Fixpoint app (l1 l2 : natlist) : natlist :=
+  match l1 with
+  | nil    => l2
+  | h :: t => h :: (app t l2)
+  end.
+Notation "x ++ y" := (app x y)
+                     (right associativity, at level 60).
+
+Definition hd (default : nat) (l : natlist) : nat :=
+  match l with
+  | nil => default
+  | h :: t => h
+  end.
+Definition tl (l : natlist) : natlist :=
+  match l with
+  | nil => nil
+  | h :: t => t
+  end.
+
+Fixpoint nonzeros (l:natlist) : natlist :=
+  match l with
+  | nil => nil
+  | h :: t => match h with
+              | O => nonzeros t
+              | S _ => h :: (nonzeros t)
+              end
+  end.
+
+Fixpoint oddmembers (l:natlist) : natlist :=
+  match l with
+  | nil => nil
+  | h :: t => match odd h with
+              | true => h :: (oddmembers t)
+              | false => oddmembers t
+              end
+  end.
+
+Definition countoddmembers (l:natlist) : nat :=
+  length (oddmembers l).
+
+
+Fixpoint alternate (l1 l2 : natlist) : natlist := 
+  match l1, l2 with
+  | nil, _ => l2
+  | _, nil => l1
+  | h1 :: t1, h2 :: t2 => h1 :: h2 :: (alternate t1 t2)
+  end.
+
+
+#[global] Instance Deq_eq_bag (b b' : natlist) : Dec (b = b').
+Proof. dec_eq. Defined.
+
+Fixpoint count (v : nat) (s : natlist) : nat :=
+  match s with
+  | nil => O
+  | h :: t => match eqb v h with
+              | true => S (count v t)
+              | false => count v t
+              end
+  end.
+
+Definition sum : natlist -> natlist -> natlist := app.
+Definition addL (v : nat) (s : natlist) : natlist := v :: s.
+Fixpoint member (v : nat) (s : natlist) : bool :=
+  match s with
+  | nil => false
+  | h :: t => match eqb v h with
+              | true => true
+              | false => member v t
+              end
+  end.
+
+Fixpoint remove_one (v : nat) (s : natlist) : natlist :=
+  match s with
+  | nil => nil
+  | h :: t => match eqb v h with
+              | true => t
+              | false => h :: (remove_one v t)
+              end
+  end.
+
+Fixpoint remove_all (v:nat) (s:natlist) : natlist :=
+  match s with
+  | nil => nil
+  | h :: t => match eqb v h with
+              | true => remove_all v t
+              | false => h :: (remove_all v t)
+              end
+  end.
+
+Fixpoint included (s1 : natlist) (s2 : natlist) : bool :=
+  match s1 with
+  | nil => true
+  | h :: t => match member h s2 with
+              | true => included t (remove_one h s2)
+              | false => false
+              end
+  end.
+
+Theorem add_inc_count : forall (b : natlist) (n : nat),
+  count n (addL n b) = S (count n b).
+Proof. quickchick. Admitted.
+
+Definition manual_grade_for_add_inc_count : option (nat*string) := None.
+
+Theorem nil_app : forall l : natlist,
+  [] ++ l = l.
+Proof. quickchick. Admitted.
+Theorem tl_length_pred : forall l:natlist,
+  pred (length l) = length (tl l).
+Proof. quickchick. Admitted.
+
+Theorem app_assoc : forall l1 l2 l3 : natlist,
+  (l1 ++ l2) ++ l3 = l1 ++ (l2 ++ l3).
+Proof. quickchick. Admitted.
+
+Fixpoint rev (l:natlist) : natlist :=
+  match l with
+  | nil    => nil
+  | h :: t => rev t ++ [h]
+  end.
+Theorem rev_length_firsttry : forall l : natlist,
+  length (rev l) = length l.
+Proof. quickchick. Admitted.
+Check length.
+Check add.
+Check (QuickChick.Checker.forAll QuickChick.Classes.arbitrary
+   (fun l1 =>
+    QuickChick.Checker.forAll QuickChick.Classes.arbitrary
+      (fun l2 =>
+       QuickChick.Checker.checker
+         match @QuickChick.Decidability.decOpt (@eq (@nat) (length (app l1 l2)) (add (length l1) (length l2))) _ 1000%nat with
+         | Coq.Init.Datatypes.Some res => res
+         | Coq.Init.Datatypes.None => Coq.Init.Datatypes.false
+         end))).
+
+
+Theorem app_length : forall l1 l2 : natlist,
+  length (l1 ++ l2) = ((length l1) + (length l2)).
+Proof. Print eq. quickchick. Admitted.
+Theorem rev_length : forall l : natlist,
+  length (rev l) = length l.
+Proof. quickchick. Admitted.
+
+
+Theorem app_nil_r : forall l : natlist,
+  l ++ [] = l.
+Proof. quickchick. Admitted.
+Theorem rev_app_distr: forall l1 l2 : natlist,
+  rev (l1 ++ l2) = rev l2 ++ rev l1.
+Proof. quickchick. Admitted.
+Theorem rev_involutive : forall l : natlist,
+  rev (rev l) = l.
+Proof. quickchick. Admitted.
+Theorem app_assoc4 : forall l1 l2 l3 l4 : natlist,
+  l1 ++ (l2 ++ (l3 ++ l4)) = ((l1 ++ l2) ++ l3) ++ l4.
+Proof. quickchick. Admitted.
+Lemma nonzeros_app : forall l1 l2 : natlist,
+  nonzeros (l1 ++ l2) = (nonzeros l1) ++ (nonzeros l2).
+Proof. quickchick. Admitted.
+Fixpoint eqblist (l1 l2 : natlist) : bool :=
+  match l1, l2 with
+  | nil, nil => true
+  | nil, _ => false
+  | _, nil => false
+  | h1 :: t1, h2 :: t2 => match eqb h1 h2 with
+                          | true => eqblist t1 t2
+                          | false => false
+                          end
+  end.
+
+Theorem eqblist_refl : forall l:natlist,
+  true = eqblist l l.
+Proof. quickchick. Admitted.
+
+Theorem count_member_nonzero : forall (s : natlist),
+  1 <=? (count 1 (1 :: s)) = true.
+Proof. quickchick. Admitted.
+Theorem leb_n_Sn : forall n,
+  n <=? (S n) = true.
+Proof. quickchick. Admitted.
+Theorem remove_does_not_increase_count: forall (s : natlist),
+  (count 0 (remove_one 0 s)) <=? (count 0 s) = true.
+Proof. quickchick. Admitted.
+
+Theorem rev_injective : forall (l1 l2 : natlist),
+  rev l1 = rev l2 -> l1 = l2.
+Proof. quickchick. Admitted.
+
+Fixpoint nth_bad (l:natlist) (n:nat) : nat :=
+  match l with
+  | nil => 42
+  | a :: l' => match n with
+               | 0 => a
+               | S n' => nth_bad l' n'
+               end
+  end.
+Inductive natoption : Type :=
+  | Some (n : nat)
+  | None.
+
+Derive Arbitrary for natoption.
+Derive Show for natoption.
+#[global] Instance Deq_eq_natoption (n n' : natoption) : Dec (n = n').
+Proof. dec_eq. Defined.
+
+Fixpoint nth_error (l:natlist) (n:nat) : natoption :=
+  match l with
+  | nil => None
+  | a :: l' => match n with
+               | O => Some a
+               | S n' => nth_error l' n'
+               end
+  end.
+
+Definition option_elim (d : nat) (o : natoption) : nat :=
+  match o with
+  | Some n' => n'
+  | None => d
+  end.
+Definition hd_error (l : natlist) : natoption :=
+  match l with
+  | x :: l' => Some x
+  | _ => None
+  end.
+  
+
+Theorem option_elim_hd : forall (l:natlist) (default:nat),
+  hd default l = option_elim default (hd_error l).
+Proof. quickchick. Admitted.
+End NatList.
+
+Inductive id : Type :=
+  | Id (n : nat).
+Derive (Show, Arbitrary) for id.
+#[global] Instance Dec_eq_id (n n' : id) : Dec (n = n').
+Proof. dec_eq. Defined.
+Definition eqb_id (x1 x2 : id) :=
+  match x1, x2 with
+  | Id n1, Id n2 => n1 =? n2
+  end.
+Theorem eqb_id_refl : forall x, eqb_id x x = true.
+Proof. quickchick. Admitted.
+Module PartialMap.
+Export NatList.  
+Inductive partial_map : Type :=
+  | empty
+  | record (i : id) (v : nat) (m : partial_map).
+Derive Show for partial_map.
+Derive Arbitrary for partial_map.
+#[global] Instance Dec_eq_partial_map (m m' : partial_map) : Dec (m = m').
+Proof. dec_eq. Defined.
+Definition update (d : partial_map)
+                  (x : id) (value : nat)
+                  : partial_map :=
+  record x value d.
+Fixpoint find (x : id) (d : partial_map) : natoption :=
+  match d with
+  | empty         => None
+  | record y v d' => if eqb_id x y
+                     then Some v
+                     else find x d'
+  end.
+Theorem update_eq :
+  forall (d : partial_map) (x : id) (v: nat),
+    find x (update d x v) = Some v.
+Proof. quickchick. Admitted.
+Theorem update_neq :
+  forall (d : partial_map) (x y : id) (o: nat),
+    eqb_id x y = false -> find x (update d y o) = find x d.
+Proof. quickchick. Admitted.
+End PartialMap.
+
+ (* 2023-10-03 16:40 *)
+
+
+  
+ (*
+Create a new file, lots of tests: trees, numbers, lists, etc.
+
+Also do preservation in a separate file STLC. 
+
+ADD THIS FILE TO QUICKCHICK TEST SUITE
+add the test file to the makefile.
+
+Push to master
+
+Create baseline.
+
+Create a new tactic that prints info about evarmaps environ, relcontext
+
+
+
+*)

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -4,11 +4,7 @@ Set Warnings "-notation-overridden,-parsing".
 From QuickChick Require Import QuickChick.
 From Coq Require Import Nat.
 From Coq Require Import Arith.Arith.
-(*From Coq Require Import Bool.Bool.*)
-(*Require Export Coq.Strings.String.*)
 From Coq Require Import Logic.FunctionalExtensionality.
-(*From Coq Require Import Lists.List.*)
-(*Import ListNotations.*)
 Set Default Goal Selector "!".
 
 Definition to_be_generated :=
@@ -217,17 +213,6 @@ Proof.
   unfold ssrbool.decidable.
   decide equality.
 Defined.
-(*
-constructor; generalize dependent T'; induction T; intros.
-  - destruct T'.
-    + left; auto.
-    + right; intros c; inversion c.
-  - destruct T'.
-    + right; intros c; inversion c.
-    + destruct (IHT1 T'1), (IHT2 T'2); subst. { left; auto. }
-      all: right; intros c; inversion c; auto.
-Defined.
- *)
 
 #[export] Instance Dec_Eq_ty : Dec_Eq ty.
 Proof. constructor. intros. apply Dec_eq_ty. Defined.
@@ -394,52 +379,7 @@ Inductive step : tm -> tm -> Prop :=
 
 where "t '-->' t'" := (step t t').
 
-(*
-Theorem step_or_wont : forall t, ({t' | step t t'}) + (forall t',  ~(step t t')).
-Proof.
-  induction t.
-  - right. intros. intros c. inversion c; subst.
-  - destruct IHt1, IHt2.
-    + destruct s, s0. left. exists (tm_app x0 t2). apply ST_App1; auto.
-    + destruct s. left. exists (tm_app x0 t2). apply ST_App1; auto.
-    + destruct s. destruct ((@dec (value t1))).
-      * apply Dec_value.
-      * left; exists (tm_app t1 x0); constructor; auto.
-      * right. intros t' c. inversion c; subst.
-        -- apply n0; constructor.
-        -- apply (n t1'), H2.
-        -- apply (n0 H1).
-    + destruct ((@dec (value t1))).
-      * apply Dec_value.
-      * destruct v.
-        -- destruct ((@dec (value t2) (Dec_value _))).
-           ++ left; eexists. constructor; auto.
-           ++ right. intros t' c. inversion c; subst; eauto.
-              ** inversion H4.
-              ** apply (H0 _ H5).
-        -- right. intros t' c; inversion c; subst; eauto.
-           ++ inversion H4.
-           ++ apply (H0 _ H5).
-        -- right. intros t' c; inversion c; subst; eauto.
-           ++ inversion H4.
-           ++ apply (H0 _ H5).
-      * right. intros t' c. inversion c; subst; eauto. apply (H _ H4).
-  - right; intros t' c. inversion c; subst.
-  - right; intros t' c. inversion c; subst.
-  - right; intros t' c. inversion c; subst.
-  - destruct IHt1.
-    + destruct H. left. eexists; constructor; eauto.
-    + destruct (dec_eq t1 tm_true).
-      * subst. left. eexists; econstructor; eauto.
-      * destruct (dec_eq t1 tm_false).
-        -- subst. left; eexists; econstructor; eauto.
-        -- right. intros t' c; inversion c; subst; eauto.
-           apply (H _ H4).
-Qed.*)
-
 Derive DecOpt for (step t t').
-
-Compute @decOpt (step tm_true tm_true) _ 42. 
 
 Reserved Notation "Gamma '|--' t '\in' T"
             (at level 101,

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -81,55 +81,53 @@ Fixpoint nat_to_bin (n:nat) : bin :=
 Theorem nat_bin_nat : forall n, bin_to_nat (nat_to_bin n) = n.
 Proof. quickchick. Admitted.
 (* ################################################################# *)
-Module NatList.
 
 Inductive natlist : Type :=
-  | nil
-  | cons (n : nat) (l : natlist).
+  | nil'
+  | cons' (n : nat) (l : natlist).
 
 Derive Show for natlist.
 Derive Arbitrary for natlist.
 #[global] Instance Dec_eq_natlist (l l' : natlist) : Dec (l = l').
 Proof. dec_eq. Defined.
 
-Fixpoint app (l l' : natlist) : natlist :=
+Fixpoint app' (l l' : natlist) : natlist :=
   match l with
-  | nil => l'
-  | cons h l => cons h (app l l')
+  | nil' => l'
+  | cons' h l => cons' h (app' l l')
   end.
 
-Fixpoint rev (l:natlist) : natlist :=
+Fixpoint rev' (l:natlist) : natlist :=
   match l with
-  | nil    => nil
-  | cons h t => app (rev t) (cons h nil)
+  | nil'    => nil'
+  | cons' h t => app' (rev' t) (cons' h nil')
   end.
 
-Fixpoint length (l : natlist) : nat :=
+Fixpoint length' (l : natlist) : nat :=
   match l with
-  | nil => 0
-  | cons _ t => S (length t)
+  | nil' => 0
+  | cons' _ t => S (length' t)
   end.
 
 Theorem app_length : forall l1 l2 : natlist,
-  length (app l1 l2) = ((length l1) + (length l2)).
+  length' (app' l1 l2) = ((length' l1) + (length' l2)).
 Proof. quickchick. Admitted.
 
 Theorem rev_app_distr: forall l1 l2 : natlist,
-  rev (app l1 l2) = app (rev l2) (rev l1).
+  rev' (app' l1 l2) = app' (rev' l2) (rev' l1).
 Proof. quickchick. Admitted.
 Theorem rev_involutive : forall l : natlist,
-  rev (rev l) = l.
+  rev' (rev' l) = l.
 Proof. quickchick. Admitted.
 
 Theorem rev_injective : forall (l1 l2 : natlist),
-  rev l1 = rev l2 -> l1 = l2.
+  rev' l1 = rev' l2 -> l1 = l2.
 Proof. quickchick. Admitted.
 
 
-End NatList.
 
 (*From Coq Require Import Strings.String.*)
-Module STLC.
+
 
 (* ================================================================= *)
 
@@ -202,7 +200,7 @@ Check elems_.
                       end}.
 
 Derive Arbitrary for tm.
-Derive Show for (value).
+Derive Show for .
 Derive Show for value.
 Derive Arbitrary for value.
 
@@ -364,7 +362,6 @@ Theorem unique_types : forall Gamma e T T',
   T = T'.
 Proof. quickchick. Admitted.
 
-End STLC.
 
 (* 2023-08-23 11:31 *)
  (* 2023-10-03 16:40 *)

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -17,164 +17,25 @@ Definition to_be_generated :=
   if (x = y)? then checker ((x = 0)?)
   else checker tt)).
 
-
-Inductive evenP : nat -> Prop :=
-| even0 : evenP 0
-| evenSS : forall n, evenP n -> evenP (S (S n)).
-
-(*Create a DecOpt instance for even*)
-#[global] 
-Instance even_dec_opt (n :nat ) : DecOpt (evenP n) :=
-  { decOpt := fun _ => Some (Nat.even n) }.
-
-
 QuickChickDebug Debug On.
 Theorem foo : forall (x y : nat) , x < 8.
-Proof.
-  quickchick.
-Admitted.
-
-Theorem add_0_r_firsttry : forall n:nat,
-    n + 0 = n.
-Proof.
-  quickchick.
-Abort.
-
-Theorem minus_n_n : forall n,
-  minus n n = 0.
-Proof.
-  quickchick.
-Abort.
-
-Theorem mul_0_r : forall n:nat,
-  n * 0 = 0.
-Proof.
-  quickchick.
-Abort.
-
-
-Theorem mul_0_r : forall n:nat,
-  n * 0 = 0.
-Proof.
-  quickchick.  Admitted.
-
-Theorem plus_n_Sm : forall n m : nat,
-  S (n + m) = n + (S m).
-Proof.
-  quickchick.  Admitted.
+Proof. quickchick. Admitted.
 
 Theorem add_comm : forall n m : nat,
   n + m = m + n.
-Proof.
-  quickchick.  Admitted.
+Proof. quickchick. Admitted.
 
 Theorem add_assoc : forall n m p : nat,
   n + (m + p) = (n + m) + p.
-Proof.
-  quickchick.  Admitted.
+Proof. quickchick. Admitted.
 
-
-Fixpoint double (n:nat) :=
-  match n with
-  | O => O
-  | S n' => S (S (double n'))
-  end.
-
-(** Use induction to prove this simple fact about [double]: *)
 Local Open Scope nat_scope.
-Lemma double_plus : forall n, double n = n + n .
-Proof.
-  quickchick.  Admitted.
-
-Fixpoint nateqb (n m : nat) :=
-  match n,m with
-  | 0, 0 => true
-  | S n, S m => nateqb n m
-  | _, _ => false
-  end.
-
-Theorem eqb_refl : forall n : nat,
-  nateqb n n = true.
-Proof. quickchick. Admitted.
-
-Theorem even_S : forall n : nat,
-  even (S n) = negb (even n).
-Proof. quickchick. Admitted.
-
-(* ################################################################# *)
-
-Theorem mult_0_plus' : forall n m : nat,
-  (n + 0 + 0) * m = n * m.
-Proof. quickchick. Admitted.
-
-Theorem plus_rearrange_firsttry : forall n m p q : nat,
-  (n + m) + (p + q) = (m + n) + (p + q).
-Proof. quickchick. Admitted.
-Theorem plus_rearrange : forall n m p q : nat,
-  (n + m) + (p + q) = (m + n) + (p + q).
-Proof. quickchick. Admitted.
-(* ################################################################# *)
-
-
-Theorem add_assoc' : forall n m p : nat,
-  n + (m + p) = (n + m) + p.
-Proof. quickchick. Admitted.
-Theorem add_assoc'' : forall n m p : nat,
-  n + (m + p) = (n + m) + p.
-Proof. quickchick. Admitted.
-
-
-
-(* Do not modify the following line: *)
-Definition manual_grade_for_add_comm_informal : option (nat*string) := None.
-
-(* Do not modify the following line: *)
-Definition manual_grade_for_eqb_refl_informal : option (nat*string) := None.
-(* ################################################################# *)
-
-Theorem add_shuffle3 : forall n m p : nat,
-  n + (m + p) = m + (n + p).
-Proof. quickchick. Admitted.
-Theorem mul_comm : forall m n : nat,
-  m * n = n * m.
-Proof. quickchick. Admitted.
 
 Search (nat -> nat -> bool).
 Theorem plus_leb_compat_l : forall (n m p : nat),
   (Nat.leb n m = true) -> (((p + n) <=? (p + m)) = true).
 Proof. quickchick. Admitted.
 
-Theorem leb_refl : forall n:nat,
-  (n <=? n) = true.
-Proof. quickchick. Admitted.
-Theorem zero_neqb_S : forall n:nat,
-  0 =? (S n) = false.
-Proof. quickchick. Admitted.
-Theorem andb_false_r : forall b : bool,
-  andb b false = false.
-Proof. quickchick. Admitted.
-Theorem S_neqb_0 : forall n:nat,
-  (S n) =? 0 = false.
-Proof. quickchick. Admitted.
-Theorem mult_1_l : forall n:nat, 1 * n = n.
-Proof. quickchick. Admitted.
-Theorem all3_spec : forall b c : bool,
-  orb
-    (andb b c)
-    (orb (negb b)
-         (negb c))
-  = true.
-Proof. quickchick. Admitted.
-Theorem mult_plus_distr_r : forall n m p : nat,
-  (n + m) * p = (n * p) + (m * p).
-Proof. quickchick. Admitted.
-Theorem mult_assoc : forall n m p : nat,
-  n * (m * p) = (n * m) * p.
-Proof. quickchick. Admitted.
-
-Theorem add_shuffle3' : forall n m p : nat,
-  n + (m + p) = m + (n + p).
-Proof. quickchick. Admitted.
 (* ################################################################# *)
 
 Inductive bin : Type :=
@@ -220,93 +81,7 @@ Fixpoint nat_to_bin (n:nat) : bin :=
 Theorem nat_bin_nat : forall n, bin_to_nat (nat_to_bin n) = n.
 Proof. quickchick. Admitted.
 (* ################################################################# *)
-
-
-
-#[global] 
-Instance bineq_dec_opt (b b' : bin ) : DecOpt (b = b') :=
-  { decOpt := fun _ => Some (bineq b b') }.
-
-
-Theorem bin_nat_bin_fails : forall b, nat_to_bin (bin_to_nat b) = b.
-Proof. quickchick. Abort.
-
-Lemma double_incr : forall n : nat, double (S n) = S (S (double n)).
-Proof. quickchick. Admitted.
-Definition double_bin (b:bin) : bin :=
-  match b with
-  | Z => Z
-  | B0 b' => B0 (B0 b')
-  | B1 b' => B0 (B1 b')
-  end.
-
-Example double_bin_zero : double_bin Z = Z.
-Proof. quickchick. Admitted.
-
-
-Lemma double_incr_bin : forall b,
-    double_bin (incr b) = incr (incr (double_bin b)).
-Proof. quickchick. Admitted.
-
-
-Fixpoint normalize (b:bin) : bin :=
-  match b with
-  | Z => Z
-  | B0 b' => match normalize b' with
-             | Z => Z
-             | b'' => B0 b''
-             end
-  | B1 b' => B1 (normalize b')
-  end.
-(* FILL IN HERE *)
-Theorem bin_nat_bin : forall b, nat_to_bin (bin_to_nat b) = normalize b.
-Proof. quickchick. Admitted.
-
 Module NatList.
-
-Inductive natprod : Type :=
-  | pair (n1 n2 : nat).
-Derive (Arbitrary, Show) for natprod.
-#[global] Instance Dec_eq_natprod (n n' : natprod) : Dec (n = n').
-Proof. dec_eq. Defined.
-Check (pair 3 5) : natprod.
-Definition fst (p : natprod) : nat :=
-  match p with
-  | pair x y => x
-  end.
-Definition snd (p : natprod) : nat :=
-  match p with
-  | pair x y => y
-  end.
-Notation "( x , y )" := (pair x y).
-Definition fst' (p : natprod) : nat :=
-  match p with
-  | (x,y) => x
-  end.
-Definition snd' (p : natprod) : nat :=
-  match p with
-  | (x,y) => y
-  end.
-Definition swap_pair (p : natprod) : natprod :=
-  match p with
-  | (x,y) => (y,x)
-  end.
-        
-Theorem surjective_pairing' : forall (n m : nat),
-  (n,m) = (fst (n,m), snd (n,m)).
-Proof. quickchick. Admitted.
-Theorem surjective_pairing_stuck : forall (p : natprod),
-  p = (fst p, snd p).
-Proof. quickchick. Admitted.
-Theorem surjective_pairing : forall (p : natprod),
-  p = (fst p, snd p).
-Proof. quickchick. Admitted.
-Theorem snd_fst_is_swap : forall (p : natprod),
-  (snd p, fst p) = swap_pair p.
-Proof. quickchick. Admitted.
-Theorem fst_swap_is_snd : forall (p : natprod),
-  fst (swap_pair p) = snd p.
-Proof. quickchick. Admitted.
 
 Inductive natlist : Type :=
   | nil
@@ -317,303 +92,270 @@ Derive Arbitrary for natlist.
 #[global] Instance Dec_eq_natlist (l l' : natlist) : Dec (l = l').
 Proof. dec_eq. Defined.
 
-Definition mylist := cons 1 (cons 2 (cons 3 nil)).
-Notation "x :: l" := (cons x l)
-                     (at level 60, right associativity).
-Notation "[ ]" := nil.
-Notation "[ x ; .. ; y ]" := (cons x .. (cons y nil) ..).
-Definition mylist1 := 1 :: (2 :: (3 :: nil)).
-Definition mylist2 := 1 :: 2 :: 3 :: nil.
-Definition mylist3 := [1;2;3].
-
-Fixpoint repeat (n count : nat) : natlist :=
-  match count with
-  | O => nil
-  | S count' => n :: (repeat n count')
-  end.
-
-Fixpoint length (l:natlist) : nat :=
+Fixpoint app (l l' : natlist) : natlist :=
   match l with
-  | nil => O
-  | h :: t => S (length t)
+  | nil => l'
+  | cons h l => cons h (app l l')
   end.
-
-Fixpoint app (l1 l2 : natlist) : natlist :=
-  match l1 with
-  | nil    => l2
-  | h :: t => h :: (app t l2)
-  end.
-Notation "x ++ y" := (app x y)
-                     (right associativity, at level 60).
-
-Definition hd (default : nat) (l : natlist) : nat :=
-  match l with
-  | nil => default
-  | h :: t => h
-  end.
-Definition tl (l : natlist) : natlist :=
-  match l with
-  | nil => nil
-  | h :: t => t
-  end.
-
-Fixpoint nonzeros (l:natlist) : natlist :=
-  match l with
-  | nil => nil
-  | h :: t => match h with
-              | O => nonzeros t
-              | S _ => h :: (nonzeros t)
-              end
-  end.
-
-Fixpoint oddmembers (l:natlist) : natlist :=
-  match l with
-  | nil => nil
-  | h :: t => match odd h with
-              | true => h :: (oddmembers t)
-              | false => oddmembers t
-              end
-  end.
-
-Definition countoddmembers (l:natlist) : nat :=
-  length (oddmembers l).
-
-
-Fixpoint alternate (l1 l2 : natlist) : natlist := 
-  match l1, l2 with
-  | nil, _ => l2
-  | _, nil => l1
-  | h1 :: t1, h2 :: t2 => h1 :: h2 :: (alternate t1 t2)
-  end.
-
-
-#[global] Instance Deq_eq_bag (b b' : natlist) : Dec (b = b').
-Proof. dec_eq. Defined.
-
-Fixpoint count (v : nat) (s : natlist) : nat :=
-  match s with
-  | nil => O
-  | h :: t => match eqb v h with
-              | true => S (count v t)
-              | false => count v t
-              end
-  end.
-
-Definition sum : natlist -> natlist -> natlist := app.
-Definition addL (v : nat) (s : natlist) : natlist := v :: s.
-Fixpoint member (v : nat) (s : natlist) : bool :=
-  match s with
-  | nil => false
-  | h :: t => match eqb v h with
-              | true => true
-              | false => member v t
-              end
-  end.
-
-Fixpoint remove_one (v : nat) (s : natlist) : natlist :=
-  match s with
-  | nil => nil
-  | h :: t => match eqb v h with
-              | true => t
-              | false => h :: (remove_one v t)
-              end
-  end.
-
-Fixpoint remove_all (v:nat) (s:natlist) : natlist :=
-  match s with
-  | nil => nil
-  | h :: t => match eqb v h with
-              | true => remove_all v t
-              | false => h :: (remove_all v t)
-              end
-  end.
-
-Fixpoint included (s1 : natlist) (s2 : natlist) : bool :=
-  match s1 with
-  | nil => true
-  | h :: t => match member h s2 with
-              | true => included t (remove_one h s2)
-              | false => false
-              end
-  end.
-
-Theorem add_inc_count : forall (b : natlist) (n : nat),
-  count n (addL n b) = S (count n b).
-Proof. quickchick. Admitted.
-
-Definition manual_grade_for_add_inc_count : option (nat*string) := None.
-
-Theorem nil_app : forall l : natlist,
-  [] ++ l = l.
-Proof. quickchick. Admitted.
-Theorem tl_length_pred : forall l:natlist,
-  pred (length l) = length (tl l).
-Proof. quickchick. Admitted.
-
-Theorem app_assoc : forall l1 l2 l3 : natlist,
-  (l1 ++ l2) ++ l3 = l1 ++ (l2 ++ l3).
-Proof. quickchick. Admitted.
 
 Fixpoint rev (l:natlist) : natlist :=
   match l with
   | nil    => nil
-  | h :: t => rev t ++ [h]
+  | cons h t => app (rev t) (cons h nil)
   end.
-Theorem rev_length_firsttry : forall l : natlist,
-  length (rev l) = length l.
-Proof. quickchick. Admitted.
-Check length.
-Check add.
-Check (QuickChick.Checker.forAll QuickChick.Classes.arbitrary
-   (fun l1 =>
-    QuickChick.Checker.forAll QuickChick.Classes.arbitrary
-      (fun l2 =>
-       QuickChick.Checker.checker
-         match @QuickChick.Decidability.decOpt (@eq (@nat) (length (app l1 l2)) (add (length l1) (length l2))) _ 1000%nat with
-         | Coq.Init.Datatypes.Some res => res
-         | Coq.Init.Datatypes.None => Coq.Init.Datatypes.false
-         end))).
 
+Fixpoint length (l : natlist) : nat :=
+  match l with
+  | nil => 0
+  | cons _ t => S (length t)
+  end.
 
 Theorem app_length : forall l1 l2 : natlist,
-  length (l1 ++ l2) = ((length l1) + (length l2)).
-Proof. Print eq. quickchick. Admitted.
-Theorem rev_length : forall l : natlist,
-  length (rev l) = length l.
+  length (app l1 l2) = ((length l1) + (length l2)).
 Proof. quickchick. Admitted.
 
-
-Theorem app_nil_r : forall l : natlist,
-  l ++ [] = l.
-Proof. quickchick. Admitted.
 Theorem rev_app_distr: forall l1 l2 : natlist,
-  rev (l1 ++ l2) = rev l2 ++ rev l1.
+  rev (app l1 l2) = app (rev l2) (rev l1).
 Proof. quickchick. Admitted.
 Theorem rev_involutive : forall l : natlist,
   rev (rev l) = l.
-Proof. quickchick. Admitted.
-Theorem app_assoc4 : forall l1 l2 l3 l4 : natlist,
-  l1 ++ (l2 ++ (l3 ++ l4)) = ((l1 ++ l2) ++ l3) ++ l4.
-Proof. quickchick. Admitted.
-Lemma nonzeros_app : forall l1 l2 : natlist,
-  nonzeros (l1 ++ l2) = (nonzeros l1) ++ (nonzeros l2).
-Proof. quickchick. Admitted.
-Fixpoint eqblist (l1 l2 : natlist) : bool :=
-  match l1, l2 with
-  | nil, nil => true
-  | nil, _ => false
-  | _, nil => false
-  | h1 :: t1, h2 :: t2 => match eqb h1 h2 with
-                          | true => eqblist t1 t2
-                          | false => false
-                          end
-  end.
-
-Theorem eqblist_refl : forall l:natlist,
-  true = eqblist l l.
-Proof. quickchick. Admitted.
-
-Theorem count_member_nonzero : forall (s : natlist),
-  1 <=? (count 1 (1 :: s)) = true.
-Proof. quickchick. Admitted.
-Theorem leb_n_Sn : forall n,
-  n <=? (S n) = true.
-Proof. quickchick. Admitted.
-Theorem remove_does_not_increase_count: forall (s : natlist),
-  (count 0 (remove_one 0 s)) <=? (count 0 s) = true.
 Proof. quickchick. Admitted.
 
 Theorem rev_injective : forall (l1 l2 : natlist),
   rev l1 = rev l2 -> l1 = l2.
 Proof. quickchick. Admitted.
 
-Fixpoint nth_bad (l:natlist) (n:nat) : nat :=
-  match l with
-  | nil => 42
-  | a :: l' => match n with
-               | 0 => a
-               | S n' => nth_bad l' n'
-               end
-  end.
-Inductive natoption : Type :=
-  | Some (n : nat)
-  | None.
-
-Derive Arbitrary for natoption.
-Derive Show for natoption.
-#[global] Instance Deq_eq_natoption (n n' : natoption) : Dec (n = n').
-Proof. dec_eq. Defined.
-
-Fixpoint nth_error (l:natlist) (n:nat) : natoption :=
-  match l with
-  | nil => None
-  | a :: l' => match n with
-               | O => Some a
-               | S n' => nth_error l' n'
-               end
-  end.
-
-Definition option_elim (d : nat) (o : natoption) : nat :=
-  match o with
-  | Some n' => n'
-  | None => d
-  end.
-Definition hd_error (l : natlist) : natoption :=
-  match l with
-  | x :: l' => Some x
-  | _ => None
-  end.
-  
-
-Theorem option_elim_hd : forall (l:natlist) (default:nat),
-  hd default l = option_elim default (hd_error l).
-Proof. quickchick. Admitted.
 End NatList.
 
-Inductive id : Type :=
-  | Id (n : nat).
-Derive (Show, Arbitrary) for id.
-#[global] Instance Dec_eq_id (n n' : id) : Dec (n = n').
-Proof. dec_eq. Defined.
-Definition eqb_id (x1 x2 : id) :=
-  match x1, x2 with
-  | Id n1, Id n2 => n1 =? n2
-  end.
-Theorem eqb_id_refl : forall x, eqb_id x x = true.
-Proof. quickchick. Admitted.
-Module PartialMap.
-Export NatList.  
-Inductive partial_map : Type :=
-  | empty
-  | record (i : id) (v : nat) (m : partial_map).
-Derive Show for partial_map.
-Derive Arbitrary for partial_map.
-#[global] Instance Dec_eq_partial_map (m m' : partial_map) : Dec (m = m').
-Proof. dec_eq. Defined.
-Definition update (d : partial_map)
-                  (x : id) (value : nat)
-                  : partial_map :=
-  record x value d.
-Fixpoint find (x : id) (d : partial_map) : natoption :=
-  match d with
-  | empty         => None
-  | record y v d' => if eqb_id x y
-                     then Some v
-                     else find x d'
-  end.
-Theorem update_eq :
-  forall (d : partial_map) (x : id) (v: nat),
-    find x (update d x v) = Some v.
-Proof. quickchick. Admitted.
-Theorem update_neq :
-  forall (d : partial_map) (x y : id) (o: nat),
-    eqb_id x y = false -> find x (update d y o) = find x d.
-Proof. quickchick. Admitted.
-End PartialMap.
+(*From Coq Require Import Strings.String.*)
+Module STLC.
 
+(* ================================================================= *)
+
+Inductive ty : Type :=
+  | Ty_Bool  : ty
+  | Ty_Arrow : ty -> ty -> ty.
+
+(* ================================================================= *)
+
+Inductive tm : Type :=
+  | tm_var   : string -> tm
+  | tm_app   : tm -> tm -> tm
+  | tm_abs   : string -> ty -> tm -> tm
+  | tm_true  : tm
+  | tm_false : tm
+  | tm_if    : tm -> tm -> tm -> tm.
+
+Declare Custom Entry stlc.
+Notation "<{ e }>" := e (e custom stlc at level 99).
+Notation "( x )" := x (in custom stlc, x at level 99).
+Notation "x" := x (in custom stlc at level 0, x constr at level 0).
+Notation "S -> T" := (Ty_Arrow S T) (in custom stlc at level 50, right associativity).
+Notation "x y" := (tm_app x y) (in custom stlc at level 1, left associativity).
+Notation "\ x : t , y" :=
+  (tm_abs x t y) (in custom stlc at level 90, x at level 99,
+                     t custom stlc at level 99,
+                     y custom stlc at level 99,
+                     left associativity).
+Coercion tm_var : string >-> tm.
+
+Notation "'Bool'" := Ty_Bool (in custom stlc at level 0).
+Notation "'if' x 'then' y 'else' z" :=
+  (tm_if x y z) (in custom stlc at level 89,
+                    x custom stlc at level 99,
+                    y custom stlc at level 99,
+                    z custom stlc at level 99,
+                    left associativity).
+Notation "'true'"  := true (at level 1).
+Notation "'true'"  := tm_true (in custom stlc at level 0).
+Notation "'false'"  := false (at level 1).
+Notation "'false'"  := tm_false (in custom stlc at level 0).
+Definition x : string := "x".
+Definition y : string := "y".
+Definition z : string := "z".
+#[local] Hint Unfold x : core.
+#[local] Hint Unfold y : core.
+#[local] Hint Unfold z : core.
+
+
+Inductive value : tm -> Prop :=
+  | v_abs : forall x T2 t1,
+      value <{\x:T2, t1}>
+  | v_true :
+      value <{true}>
+  | v_false :
+      value <{false}>.
+
+(*Derive show and Arbitrary*)
+Derive Show for ty.
+Derive Arbitrary for ty.
+Derive Show for tm.
+Derive Arbitrary for tm.
+Derive Show for value.
+Derive Arbitrary for value.
+
+(*Create Dec eq instances*)
+#[global] Instance Dec_eq_ty (T T' : ty) : Dec (T = T').
+Proof. dec_eq. Defined.
+
+#[global] Instance Dec_eq_tm (t t' : tm) : Dec (t = t').
+Proof. dec_eq. Defined.
+
+Hint Constructors value : core.
+
+(* ================================================================= *)
+
+Reserved Notation "'[' x ':=' s ']' t" (in custom stlc at level 20, x constr).
+
+Fixpoint subst (x : string) (s : tm) (t : tm) : tm :=
+  match t with
+  | tm_var y =>
+      if String.eqb x y then s else t
+  | <{\y:T, t1}> =>
+      if String.eqb x y then t else <{\y:T, [x:=s] t1}>
+  | <{t1 t2}> =>
+      <{([x:=s] t1) ([x:=s] t2)}>
+  | <{true}> =>
+      <{true}>
+  | <{false}> =>
+      <{false}>
+  | <{if t1 then t2 else t3}> =>
+      <{if ([x:=s] t1) then ([x:=s] t2) else ([x:=s] t3)}>
+  end
+
+where "'[' x ':=' s ']' t" := (subst x s t) (in custom stlc).
+Check <{[x:=true] x}>.
+
+
+Print tm.
+Inductive substi (s : tm) (x : string) : tm -> tm -> Prop :=
+  | s_var_eq :
+      substi s x (tm_var x) s
+  | s_var_neq : forall y,
+      x <> y ->
+      substi s x (tm_var y) (tm_var y)
+  | s_abs_eq : forall T e,
+      substi s x (tm_abs x T e) (tm_abs x T e)
+  | s_abs_neq : forall y T e e',
+      x <> y ->
+      substi s x e e' ->
+      substi s x (tm_abs y T e) (tm_abs y T e')
+  | s_app : forall f y f' y',
+      substi s x f f' ->
+      substi s x y y' ->
+      substi s x (tm_app f y) (tm_app f' y')
+  | s_true : substi s x tm_true tm_true
+  | s_false : substi s x tm_false tm_false
+  | s_if : forall b b' t t' f f',
+      substi s x b b' ->
+      substi s x t t' ->
+      substi s x f f' -> 
+      substi s x (tm_if b t f) (tm_if b' t' f')
+.
+
+Hint Constructors substi : core.
+
+(*Derive show and arbitrary*)
+Derive Show for substi.
+Derive Arbitrary for substi.
+
+Theorem substi_correct : forall s x t t',
+  <{ [x:=s]t }> = t' <-> substi s x t t'.
+Proof. quickchick. Admitted.
+
+(* ================================================================= *)
+
+
+Reserved Notation "t '-->' t'" (at level 40).
+
+Inductive step : tm -> tm -> Prop :=
+  | ST_AppAbs : forall x T2 t1 v2,
+         value v2 ->
+         <{(\x:T2, t1) v2}> --> <{ [x:=v2]t1 }>
+  | ST_App1 : forall t1 t1' t2,
+         t1 --> t1' ->
+         <{t1 t2}> --> <{t1' t2}>
+  | ST_App2 : forall v1 t2 t2',
+         value v1 ->
+         t2 --> t2' ->
+         <{v1 t2}> --> <{v1  t2'}>
+  | ST_IfTrue : forall t1 t2,
+      <{if true then t1 else t2}> --> t1
+  | ST_IfFalse : forall t1 t2,
+      <{if false then t1 else t2}> --> t2
+  | ST_If : forall t1 t1' t2 t3,
+      t1 --> t1' ->
+      <{if t1 then t2 else t3}> --> <{if t1' then t2 else t3}>
+
+where "t '-->' t'" := (step t t').
+
+Reserved Notation "Gamma '|--' t '\in' T"
+            (at level 101,
+             t custom stlc, T custom stlc at level 0).
+ Print Grammar constr.
+Inductive has_type : (tm -> option ty) -> tm -> ty -> Prop :=
+  | T_Var : forall Gamma x T1,
+      Gamma x = Some T1 ->
+      Gamma |-- x \in T1
+  | T_Abs : forall Gamma x T1 T2 t1,
+      x |-> T2 ; Gamma |-- t1 \in T1 ->
+      Gamma |-- \x:T2, t1 \in (T2 -> T1)
+  | T_App : forall T1 T2 Gamma t1 t2,
+      Gamma |-- t1 \in (T2 -> T1) ->
+      Gamma |-- t2 \in T2 ->
+      Gamma |-- t1 t2 \in T1
+  | T_True : forall Gamma,
+       Gamma |-- true \in Bool
+  | T_False : forall Gamma,
+       Gamma |-- false \in Bool
+  | T_If : forall t1 t2 t3 T1 Gamma,
+       Gamma |-- t1 \in Bool ->
+       Gamma |-- t2 \in T1 ->
+       Gamma |-- t3 \in T1 ->
+       Gamma |-- if t1 then t2 else t3 \in T1
+
+where "Gamma '|--' t '\in' T" := (has_type Gamma t T).
+
+
+
+Hint Constructors has_type : core.
+
+(*Derive show and arbitrary*)
+Derive Show for has_type.
+Derive Arbitrary for has_type.
+
+Lemma canonical_forms_bool : forall t,
+  empty |-- t \in Bool ->
+  value t ->
+  (t = <{true}>) \/ (t = <{false}>).
+Proof. quickchick. Admitted.
+
+Lemma weakening_empty : forall Gamma t T,
+     empty |-- t \in T  ->
+     Gamma |-- t \in T.
+Proof. quickchick. Admitted.
+
+Theorem progress : forall t T,
+  empty |-- t \in T ->
+  value t \/ exists t', t --> t'.
+Proof. quickchick. Admitted.
+
+Theorem preservation : forall t t' T,
+  empty |-- t \in T  ->
+  t --> t'  ->
+  empty |-- t' \in T.
+Proof. quickchick. Admitted.
+
+Theorem unique_types : forall Gamma e T T',
+  Gamma |-- e \in T ->
+  Gamma |-- e \in T' ->
+  T = T'.
+Proof. quickchick. Admitted.
+
+End STLC.
+
+(* 2023-08-23 11:31 *)
  (* 2023-10-03 16:40 *)
-
-
   
  (*
 Create a new file, lots of tests: trees, numbers, lists, etc.
@@ -628,7 +370,5 @@ Push to master
 Create baseline.
 
 Create a new tactic that prints info about evarmaps environ, relcontext
-
-
 
 *)

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -516,7 +516,7 @@ Lemma canonical_forms_bool : forall term,
 Proof. quickchick. Admitted.
 
 (* Quantifying over the type string -> option for Gamma causes bug.
-   "Failure("id_of_name called with anonymous").
+   Failure(id_of_name called with anonymous).
 Lemma weakening_empty : forall Gamma e T,
      empty_env |-- e \in T  ->
      has_type Gamma e T.

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -9,6 +9,7 @@ Definition to_be_generated :=
   else checker tt)).
 
 QuickChickDebug Debug On.
-Theorem foo : forall (x y: nat) , x = y -> x = 0.
+Theorem foo : forall (x y: nat) , x = y -> x <> 0.
 Proof.
   quickchick.
+Abort.

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -454,10 +454,6 @@ Derive DecOpt for (has_type Gamma t T).
 
 Hint Constructors has_type : core.
 
-(*Derive show and arbitrary*)
-Derive Show for has_type.
-Derive Arbitrary for has_type.
-
 Lemma canonical_forms_bool : forall t,
   empty |-- t \in Bool ->
   value t ->

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -213,7 +213,12 @@ Derive Show for tm.
 (*Create Dec eq instances*)
 #[export] Instance Dec_eq_ty (T T' : ty) : Dec (T = T').
 Proof.
-  constructor; generalize dependent T'; induction T; intros.
+  constructor.
+  unfold ssrbool.decidable.
+  decide equality.
+Defined.
+(*
+constructor; generalize dependent T'; induction T; intros.
   - destruct T'.
     + left; auto.
     + right; intros c; inversion c.
@@ -222,6 +227,7 @@ Proof.
     + destruct (IHT1 T'1), (IHT2 T'2); subst. { left; auto. }
       all: right; intros c; inversion c; auto.
 Defined.
+ *)
 
 #[export] Instance Dec_Eq_ty : Dec_Eq ty.
 Proof. constructor. intros. apply Dec_eq_ty. Defined.
@@ -387,6 +393,7 @@ Inductive step : tm -> tm -> Prop :=
       <{if t1 then t2 else t3}> --> <{if t1' then t2 else t3}>
 
 where "t '-->' t'" := (step t t').
+
 (*
 Theorem step_or_wont : forall t, ({t' | step t t'}) + (forall t',  ~(step t t')).
 Proof.
@@ -432,8 +439,7 @@ Qed.*)
 
 Derive DecOpt for (step t t').
 
-Compute @decOpt (step tm_true tm_true) _.
-                  
+Compute @decOpt (step tm_true tm_true) _ 42. 
 
 Reserved Notation "Gamma '|--' t '\in' T"
             (at level 101,
@@ -590,29 +596,3 @@ Theorem preservation : forall e e' T,
   empty_env |-- e' \in T.
 Proof. quickchick. Admitted.
 
-(* Quantifying over Gamma causes error: id_of_name called with anonymous."
-Theorem unique_types : forall Gamma e T T',
-  Gamma |-- e \in T ->
-  Gamma |-- e \in T' ->
-  T = T'.
-Proof. quickchick. Admitted.
-*)
-
-(* 2023-08-23 11:31 *)
- (* 2023-10-03 16:40 *)
-  
- (*
-Create a new file, lots of tests: trees, numbers, lists, etc.
-
-Also do preservation in a separate file STLC. 
-
-ADD THIS FILE TO QUICKCHICK TEST SUITE
-add the test file to the makefile.
-
-Push to master
-
-Create baseline.
-
-Create a new tactic that prints info about evarmaps environ, relcontext
-
-*)

--- a/examples/TacticExample.v
+++ b/examples/TacticExample.v
@@ -125,6 +125,7 @@ Theorem rev_injective : forall (l1 l2 : natlist),
   rev l1 = rev l2 -> l1 = l2.
 Proof. quickchick. Admitted.
 
+
 End NatList.
 
 (*From Coq Require Import Strings.String.*)
@@ -145,6 +146,7 @@ Inductive tm : Type :=
   | tm_true  : tm
   | tm_false : tm
   | tm_if    : tm -> tm -> tm -> tm.
+
 
 Declare Custom Entry stlc.
 Notation "<{ e }>" := e (e custom stlc at level 99).
@@ -177,7 +179,6 @@ Definition z : string := "z".
 #[local] Hint Unfold y : core.
 #[local] Hint Unfold z : core.
 
-
 Inductive value : tm -> Prop :=
   | v_abs : forall x T2 t1,
       value <{\x:T2, t1}>
@@ -189,8 +190,19 @@ Inductive value : tm -> Prop :=
 (*Derive show and Arbitrary*)
 Derive Show for ty.
 Derive Arbitrary for ty.
-Derive Show for tm.
+Check elems_.
+#[export] Instance Gen_var : Gen string :=
+  {arbitrary := elems_ x (cons x (cons y (cons z nil)))}.
+
+#[export] Instance shrink_var : Shrink string :=
+  {shrink := fun s => match s with
+                      | "x"%string => cons y (cons z nil)
+                      | "y"%string => cons z nil
+                      | _ => nil
+                      end}.
+
 Derive Arbitrary for tm.
+Derive Show for (value).
 Derive Show for value.
 Derive Arbitrary for value.
 

--- a/examples/stlc/verif.v
+++ b/examples/stlc/verif.v
@@ -150,7 +150,7 @@ Lemma max_const_Const_leq :
 Proof.
   intros. induction t; try (constructor; simpl; lia);
   constructor; simpl; eapply Const_leq_trans; try eassumption;
-  (try now apply Max.le_max_l); (try now apply Max.le_max_r); lia.
+  (try now apply PeanoNat.Nat.le_max_l); (try now apply PeanoNat.Nat.le_max_r); lia.
 Qed.
 
 (*

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -48,6 +48,8 @@ let id_of_name n =
 
 type coq_expr = constr_expr (* Opaque *)
 
+let interp_open_coq_expr env evd e = fst (Constrintern.interp_constr env evd e)
+
 let debug_coq_expr (c : coq_expr) : unit =
   let env = Global.env () in
   let sigma = Evd.from_env env in
@@ -753,6 +755,7 @@ let gType ty_params dep_type =
   aux dep_type
   
 let gType' ty_params dep_type = 
+  msg_debug (str "Calling gType' with: " ++ str (dep_type_to_string dep_type) ++ fnl ());
   let rec aux dt : coq_expr = 
     match dt with
     | DArrow (dt1, dt2) -> let t1 = aux dt1 in
@@ -762,14 +765,14 @@ let gType' ty_params dep_type =
                               let t2 = aux dt2 in 
                               gProdWithArgs [gArg ~assumName:(gVar x) ~assumType:t1 ()] (fun _ -> t2)
     | DTyParam tp -> gTyParam tp
-    | DTyCtr (c,dts) -> gApp (gTyCtr c) (List.map aux dts)
+    | DTyCtr (c,dts) -> gApp ~explicit:true (gTyCtr c) (List.map aux dts)
     | DCtr (c, dts) -> gApp (gCtr c) (List.map aux dts)
     | DTyVar x -> gVar x 
     | DApp (c, dts) -> gApp (aux c) (List.map aux dts) 
     | DHole -> hole
     | DNot dt -> gApp (gInject "Coq.Init.Logic.not") [aux dt]
   in 
-  aux dep_type
+  debug_coq_expr (aux dep_type); aux dep_type
   
 (*    
   match ty_params with 
@@ -1068,9 +1071,12 @@ let glt x y = gle (gApp (gInject "Coq.Init.Datatypes.S") [x]) y
 let gEq x y = gApp (gInject "Coq.Init.Logic.eq") [x; y]
             
 (* option type in Coq *)
-let gNone typ = gApp ~explicit:true (gInject "Coq.Init.Datatypes.None") [typ]
-let gSome typ c = gApp ~explicit:true (gInject "Coq.Init.Datatypes.Some") [typ; c]
-              
+let gNone typ = gApp ?explicit:(Some true) (gInject "Coq.Init.Datatypes.None") [typ]
+let gSome typ c = gApp ?explicit:(Some true) (gInject "Coq.Init.Datatypes.Some") [typ; c]
+        
+let gNone' = gInject "Coq.Init.Datatypes.None"
+let gSome' c = gApp (gInject "Coq.Init.Datatypes.Some") [c]
+
 let gOption c = gApp (gInject "Coq.Init.Datatypes.option") [c]
 
 (* Boolean *)
@@ -1087,8 +1093,8 @@ let decToBool c =
     ]
 
 let decOptToBool c = 
-  gMatch c [ (injectCtr "Coq.Init.Datatypes.Some", ["typ";"res"], fun [typ;res] -> gVar res)
-           ; (injectCtr "Coq.Init.Datatypes.None",       ["typ"], fun [typ] -> g_false)
+  gMatch c [ (injectCtr "Coq.Init.Datatypes.Some", ["res"], fun [res] -> gVar res)
+           ; (injectCtr "Coq.Init.Datatypes.None",       [], fun [] -> g_false)
   ]
 
 (* Unit *)
@@ -1097,18 +1103,23 @@ let gTT   = gInject "Coq.Init.Datatypes.tt"
 
 (* dec *)
 
-let g_dec typ = gApp ?explicit:(Some true) (gInject "QuickChick.dec") [typ]
-let g_decOpt typ n = gApp ?explicit:(Some true) (gInject "QuickChick.decOpt") [typ; n]
+let g_dec typ = gApp ?explicit:(Some true) (gInject "QuickChick.Decidability.dec") [typ]
+let g_decOpt typ n = gApp ?explicit:(Some true) (gInject "QuickChick.Decidability.decOpt") [typ; hole; n]
+let g_dec_decOpt = gInject "QuickChick.Decidability.dec_decOpt"
 
 (* checker *)
 
-let g_checker toCheck = gApp (gInject "QuickChick.checker") [toCheck]
+let g_checker toCheck = gApp (gInject "QuickChick.Checker.checker") [toCheck]
 
 (* Gen combinators *)
 
-let g_forAll gen prop = gApp (gInject "QuickChick.forAll") [gen; prop]
+let g_forAll gen prop = gApp (gInject "QuickChick.Checker.forAll") [gen; prop]
 
-let g_arbitrary = gInject "QuickChick.arbitrary"
+let g_arbitrary = gInject "QuickChick.Classes.arbitrary"
+
+let g_quickCheck p = gApp (gInject "QuickChick.Test.quickCheck") [p]
+
+let g_show typ = gApp (gInject "QuickChick.Show.show") [typ]
 
 (* Recursion combinators / fold *)
 (* fold_ty : ( a -> coq_type -> a ) -> ( ty_ctr * coq_type list -> a ) -> ( ty_param -> a ) -> coq_type -> a *)

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -75,12 +75,8 @@ let gInject s =
   if s = "" then failwith "Called gInject with empty string";
   CAst.make @@ CRef (qualid_of_string s, None)
 
-#if COQ_VERSION >= (8, 19, 0)
-let gType0 = CAst.make @@ CSort (Glob_term.UAnonymous {rigid = UnivRigid})
-#else
 let gType0 = CAst.make @@ CSort (Glob_term.UAnonymous {rigid = true})
-#endif
-
+         
 type ty_param = Id.t (* Opaque *)
 let ty_param_to_string (x : ty_param) = Id.to_string x
 let inject_ty_param (s : string) : ty_param = Id.of_string s
@@ -425,7 +421,7 @@ let rec dep_arrowify terminal names types =
    nparams : number of <Type> parameters in the beginning
    arg_names : argument names (type parameters, pattern specific variables 
  *)
-let parse_dependent_type i nparams ty oib arg_names = 
+let parse_dependent_type_internal i nparams ty oibopt arg_names =
   let rec aux i ty =
     let env = Global.env () in
     let sigma = Evd.from_env env in
@@ -435,7 +431,7 @@ let parse_dependent_type i nparams ty oib arg_names =
   (*        msgerr (int (i + nparams) ++ str " Rel " ++ int (destRel ty) ++ fnl ()); *)
       let db = destRel ty in
       if i + nparams = db then (* Current inductive, no params *)
-        Some (DTyCtr (qualid_of_ident oib.mind_typename, []))
+        Some (DTyCtr (qualid_of_ident (let Some oib = oibopt in oib.mind_typename), []))
       else begin (* [i + nparams - db]th parameter *) 
         msg_debug (str (Printf.sprintf "Non-self-rel: %s" (dep_type_to_string (List.nth arg_names (i + nparams - db - 1)))) ++ fnl ());
         try Some (List.nth arg_names (i + nparams - db - 1))
@@ -510,6 +506,23 @@ let parse_dependent_type i nparams ty oib arg_names =
     ) in
   aux i ty
 
+let parse_dependent_type ty =
+
+    let (ctr_pats, result) = if isConst ty then ([],ty) else Term.decompose_prod ty in
+
+    let pat_names, pat_types = List.split (List.rev ctr_pats) in
+
+    let pat_names = List.map (fun n -> n.binder_name) pat_names in
+    let arg_names = 
+      List.map (fun n -> match n with
+                         | Name x -> DTyVar x 
+                         | Anonymous -> DTyVar (make_up_name ()) (* Make up a name, but probably can't be used *)
+               ) pat_names in 
+
+    parse_dependent_type_internal (1 + (List.length ctr_pats)) 0 result None arg_names >>= fun result_ty ->
+    sequenceM (fun x -> x) (List.mapi (fun i ty -> parse_dependent_type_internal i 0 ty None arg_names) (List.map (Vars.lift (-1)) pat_types)) >>= fun types ->
+    Some (dep_arrowify result_ty pat_names types)
+  
 let dep_parse_type nparams param_names arity_ctxt oib =
   let len = List.length arity_ctxt in
   (* Only type parameters can be used - no dependencies on the types *)
@@ -523,8 +536,8 @@ let dep_parse_type nparams param_names arity_ctxt oib =
            match n with
            | Name id -> (* Check if it is a parameter to add its type / name *)
               if is_Type t then Some acc 
-              else parse_dependent_type i nparams t oib arg_names >>= fun dt -> Some ((n,dt) :: acc)
-           | _ ->  parse_dependent_type i nparams t oib arg_names >>= fun dt -> Some ((n,dt) :: acc)
+              else parse_dependent_type_internal i nparams t (Some oib) arg_names >>= fun dt -> Some ((n,dt) :: acc)
+           | _ ->  parse_dependent_type_internal i nparams t (Some oib) arg_names >>= fun dt -> Some ((n,dt) :: acc)
         ) (Some []) (List.mapi (fun i x -> (len - nparams - i, x)) arity_ctxt) >>= fun nts ->
   let (names, types) = List.split nts in
   Some (dep_arrowify (DTyCtr (injectCtr "Prop", [])) names types)
@@ -555,10 +568,10 @@ let dep_parse_constructors nparams param_names oib : dep_ctr list option =
                ) pat_names in 
 
 (*     msgerr (str "Calculating result type" ++ fnl ()); *)
-    parse_dependent_type (1 + (List.length ctr_pats)) nparams result oib arg_names >>= fun result_ty ->
+    parse_dependent_type_internal (1 + (List.length ctr_pats)) nparams result (Some oib) arg_names >>= fun result_ty ->
 
 (*     msgerr (str "Calculating types" ++ fnl ()); *)
-    sequenceM (fun x -> x) (List.mapi (fun i ty -> parse_dependent_type i nparams ty oib arg_names) (List.map (Vars.lift (-1)) pat_types)) >>= fun types ->
+    sequenceM (fun x -> x) (List.mapi (fun i ty -> parse_dependent_type_internal i nparams ty (Some oib) arg_names) (List.map (Vars.lift (-1)) pat_types)) >>= fun types ->
     Some (ctr_id, dep_arrowify result_ty pat_names types)
   in
 
@@ -617,6 +630,8 @@ let gFunWithArgs args f_body =
                      ) args in
   let fun_body = f_body xvs in
   mkCLambdaN args fun_body
+
+let gIf b t f = CAst.make @@ CIf (b, (None, None) , t, f)
 
 let gFun xss (f_body : var list -> coq_expr) =
   match xss with
@@ -1054,6 +1069,20 @@ let decToBool c =
 (* Unit *)
 let gUnit = gInject "Coq.Init.Datatypes.unit"
 let gTT   = gInject "Coq.Init.Datatypes.tt"
+
+(* dec *)
+
+let g_dec typ = gApp ?explicit:(Some true) (gInject "QuickChick.dec") [typ]
+
+(* checker *)
+
+let g_checker toCheck = gApp (gInject "QuickChick.checker") [toCheck]
+
+(* Gen combinators *)
+
+let g_forAll gen prop = gApp (gInject "QuickChick.forAll") [gen; prop]
+
+let g_arbitrary = gInject "QuickChick.arbitrary"
 
 (* Recursion combinators / fold *)
 (* fold_ty : ( a -> coq_type -> a ) -> ( ty_ctr * coq_type list -> a ) -> ( ty_param -> a ) -> coq_type -> a *)

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -751,6 +751,26 @@ let gType ty_params dep_type =
     | DNot dt -> gApp (gInject "Coq.Init.Datatypes.negb") [aux dt]
   in 
   aux dep_type
+  
+let gType' ty_params dep_type = 
+  let rec aux dt : coq_expr = 
+    match dt with
+    | DArrow (dt1, dt2) -> let t1 = aux dt1 in
+                           let t2 = aux dt2 in 
+                           gFunWithArgs [gArg ~assumType:t1 ()] (fun _ -> t2)
+    | DProd ((x,dt1), dt2) -> let t1 = aux dt1 in
+                              let t2 = aux dt2 in 
+                              gProdWithArgs [gArg ~assumName:(gVar x) ~assumType:t1 ()] (fun _ -> t2)
+    | DTyParam tp -> gTyParam tp
+    | DTyCtr (c,dts) -> gApp (gTyCtr c) (List.map aux dts)
+    | DCtr (c, dts) -> gApp (gCtr c) (List.map aux dts)
+    | DTyVar x -> gVar x 
+    | DApp (c, dts) -> gApp (aux c) (List.map aux dts) 
+    | DHole -> hole
+    | DNot dt -> gApp (gInject "Coq.Init.Logic.not") [aux dt]
+  in 
+  aux dep_type
+  
 (*    
   match ty_params with 
   | [] -> aux dep_type 
@@ -1066,6 +1086,11 @@ let decToBool c =
            ; (injectCtr "Coq.Init.Specif.right", ["neq"], fun _ -> g_false)
     ]
 
+let decOptToBool c = 
+  gMatch c [ (injectCtr "Coq.Init.Datatypes.Some", ["typ";"res"], fun [typ;res] -> gVar res)
+           ; (injectCtr "Coq.Init.Datatypes.None",       ["typ"], fun [typ] -> g_false)
+  ]
+
 (* Unit *)
 let gUnit = gInject "Coq.Init.Datatypes.unit"
 let gTT   = gInject "Coq.Init.Datatypes.tt"
@@ -1073,6 +1098,7 @@ let gTT   = gInject "Coq.Init.Datatypes.tt"
 (* dec *)
 
 let g_dec typ = gApp ?explicit:(Some true) (gInject "QuickChick.dec") [typ]
+let g_decOpt typ n = gApp ?explicit:(Some true) (gInject "QuickChick.decOpt") [typ; n]
 
 (* checker *)
 

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -79,7 +79,11 @@ let gInject s =
   if s = "" then failwith "Called gInject with empty string";
   CAst.make @@ CRef (qualid_of_string s, None)
 
+#if COQ_VERSION >= (8, 19, 0)
+let gType0 = CAst.make @@ CSort (Glob_term.UAnonymous {rigid = UnivRigid})
+#else
 let gType0 = CAst.make @@ CSort (Glob_term.UAnonymous {rigid = true})
+#endif
          
 type ty_param = Id.t (* Opaque *)
 let ty_param_to_string (x : ty_param) = Id.to_string x

--- a/plugin/genericLib.mli
+++ b/plugin/genericLib.mli
@@ -4,6 +4,9 @@ open Constrexpr
 
 type coq_expr
 
+val interp_open_coq_expr : Environ.env -> Evd.evar_map -> 
+  coq_expr -> EConstr.constr
+
 val hole : coq_expr
 
 val debug_coq_expr : coq_expr -> unit
@@ -205,6 +208,9 @@ val gEq : coq_expr -> coq_expr -> coq_expr
 val gOption : coq_expr -> coq_expr
 val gNone : coq_expr -> coq_expr
 val gSome : coq_expr -> coq_expr -> coq_expr
+val gNone' : coq_expr
+val gSome' : coq_expr -> coq_expr
+
 
 (* boolean *)
 val gNot   : coq_expr -> coq_expr
@@ -224,6 +230,7 @@ val gTT   : coq_expr
 (* dec *)
 val g_dec : coq_expr -> coq_expr
 val g_decOpt : coq_expr -> coq_expr -> coq_expr
+val g_dec_decOpt : coq_expr
 
 (* checker *)
 
@@ -233,6 +240,8 @@ val g_checker : coq_expr -> coq_expr
 (* (\* Gen combinators *\) *)
 val g_forAll : coq_expr -> coq_expr -> coq_expr
 val g_arbitrary : coq_expr
+val g_quickCheck : coq_expr -> coq_expr
+val g_show : coq_expr -> coq_expr
 
 (* val gGen : coq_expr -> coq_expr *)
 (* val returnGen  : coq_expr -> coq_expr  *)

--- a/plugin/genericLib.mli
+++ b/plugin/genericLib.mli
@@ -103,6 +103,7 @@ val dep_dt_to_string : dep_dt -> string
 
 val constr_of_type : string -> ty_param list -> dep_type -> Constr.t
 val gType : ty_param list -> dep_type -> coq_expr
+val gType' : ty_param list -> dep_type -> coq_expr
 val get_type : Id.t -> unit
 val is_inductive : constructor -> bool
 val is_inductive_dt : dep_type -> bool
@@ -210,6 +211,7 @@ val gNot   : coq_expr -> coq_expr
 val g_true  : coq_expr
 val g_false : coq_expr               
 val decToBool : coq_expr -> coq_expr
+val decOptToBool : coq_expr -> coq_expr
 val gBool  : coq_expr
 val gIf : coq_expr -> coq_expr -> coq_expr -> coq_expr
 
@@ -221,6 +223,7 @@ val gTT   : coq_expr
 
 (* dec *)
 val g_dec : coq_expr -> coq_expr
+val g_decOpt : coq_expr -> coq_expr -> coq_expr
 
 (* checker *)
 

--- a/plugin/genericLib.mli
+++ b/plugin/genericLib.mli
@@ -125,6 +125,8 @@ val qualid_to_mib : Libnames.qualid -> mutual_inductive_body
 val dt_rep_from_mib : mutual_inductive_body -> dt_rep option
 val coerce_reference_to_dt_rep : constr_expr -> dt_rep option
 
+val parse_dependent_type : Constr.constr -> dep_type option
+
 val dep_dt_from_mib : mutual_inductive_body -> dep_dt option
 val coerce_reference_to_dep_dt : constr_expr -> dep_dt option
 
@@ -209,12 +211,26 @@ val g_true  : coq_expr
 val g_false : coq_expr               
 val decToBool : coq_expr -> coq_expr
 val gBool  : coq_expr
+val gIf : coq_expr -> coq_expr -> coq_expr -> coq_expr
+
+(* list *)
 
 (* unit *)
 val gUnit : coq_expr
 val gTT   : coq_expr
-  
+
+(* dec *)
+val g_dec : coq_expr -> coq_expr
+
+(* checker *)
+
+val g_checker : coq_expr -> coq_expr
+
+
 (* (\* Gen combinators *\) *)
+val g_forAll : coq_expr -> coq_expr -> coq_expr
+val g_arbitrary : coq_expr
+
 (* val gGen : coq_expr -> coq_expr *)
 (* val returnGen  : coq_expr -> coq_expr  *)
 (* val bindGen    : coq_expr -> string -> (var -> coq_expr) -> coq_expr  *)

--- a/plugin/quickChick.mlg
+++ b/plugin/quickChick.mlg
@@ -116,7 +116,7 @@ let define c env evd =
   let fn = fresh_name "quickchick" in
   (* TODO: Maxime - which of the new internal flags should be used here? The names aren't as clear :) *)
   let _ : Constant.t = declare_constant ~name:fn ~kind:Decls.(IsDefinition Definition)
-      (DefinitionEntry (definition_entry ~univs (EConstr.to_constr evd c))) in
+      (DefinitionEntry (definition_entry ~univs (EConstr.to_constr ~abort_on_undefined_evars:false evd c))) in
   fn
 
 (* [$TMP/QuickChick/$TIME/QuickChick.ml],

--- a/plugin/tactic_quickchick.mlg.cppo
+++ b/plugin/tactic_quickchick.mlg.cppo
@@ -98,7 +98,36 @@ let quickchick_goal =
     let c = Proofview.Goal.concl gl in
     let e = Proofview.Goal.env gl in
     let evd = Evd.from_env e in
+(*
+    (* Make an evar with the goal as the type *)
+    let evd, evar = Evarutil.new_pure_evar (Environ.named_context_val e) evd c in
+    
+    (* Externalize it *)
+#if COQ_VERSION >= (8, 17, 0)
+    let ct = Constrextern.extern_constr e evd (EConstr.mkEvar (evar, SList.empty)) in
+#else
+    let ct = Constrextern.extern_constr e evd (EConstr.mkEvar (evar, [])) in
+#endif
+ *)  
+  match GenericLib.parse_dependent_type (EConstr.to_constr evd c) with
+    | Some dt ->
+      begin
+        msg_debug (str (GenericLib.dep_type_to_string dt) ++ fnl ());
+        let decide prop = GenericLib.decToBool (GenericLib.g_dec prop) in
+        let checker = GenericLib.g_forAll GenericLib.g_arbitrary (GenericLib.gFun ["x"] (fun [x] -> 
+              GenericLib.g_forAll GenericLib.g_arbitrary (GenericLib.gFun ["y"] (fun [y] -> 
+                GenericLib.gIf (decide (GenericLib.gEq (GenericLib.gVar x) (GenericLib.gVar y))) 
+                              (GenericLib.g_checker (decide (GenericLib.gEq (GenericLib.gVar x) (GenericLib.gInt 0)))) 
+                               (GenericLib.g_checker GenericLib.gTT)
+               ))        
+             )) in
+        GenericLib.debug_coq_expr checker;
+        Tacticals.tclIDTAC
+      end
+    | None -> failwith "Failed to Parse type"
+  end
 
+(*    
     (* Make an evar with the goal as the type *)
     let evd, evar = Evarutil.new_pure_evar (Environ.named_context_val e) evd c in
 
@@ -224,12 +253,12 @@ let quickchick_goal =
   end
  *)
 
+*)
 }
-
 TACTIC EXTEND quickchick
   | ["quickchick"] -> { quickchick_goal }
 END
-
+(*
 TACTIC EXTEND merge_sound_core
   | ["merge_sound_core"] -> { merge_sound }
 END
@@ -237,3 +266,4 @@ END
 TACTIC EXTEND remember_induct
   | ["remember_induct" ident(h)] -> { remember_induct h }
 END
+*)

--- a/plugin/tactic_quickchick.mlg.cppo
+++ b/plugin/tactic_quickchick.mlg.cppo
@@ -9,6 +9,7 @@ MAKE SURE TO EDIT THE .cppo SOURCE OF THIS FILE RATHER THAN THE GENERATED RESULT
   open Ltac_plugin
   open Error
   open Pp
+  open Stdarg
 
 }
 

--- a/plugin/tactic_quickchick.mlg.cppo
+++ b/plugin/tactic_quickchick.mlg.cppo
@@ -10,6 +10,7 @@ MAKE SURE TO EDIT THE .cppo SOURCE OF THIS FILE RATHER THAN THE GENERATED RESULT
   open Ltac_plugin
   open Error
   open Pp
+  open QuickChick
 }
 
 DECLARE PLUGIN "coq-quickchick.plugin"
@@ -120,7 +121,7 @@ let quickchick_goal =
               g_forAll g_arbitrary (gFun [var_to_string var] (fun [_] ->
                 mkProperty body
                 )) 
-          | DArrow (x,y) -> gIf (decide (gType' [] x)) (mkProperty y) (g_checker gTT)
+          | DArrow (x,y) -> GenericLib.debug_coq_expr (gType' [] x); gIf (decide (gType' [] x)) (mkProperty y) (g_checker gTT)
           | p -> g_checker (decide (gType' [] p)) 
               in
           
@@ -139,8 +140,15 @@ let quickchick_goal =
                   (g_checker gTT)
                ))        
              )) in
+            
         GenericLib.debug_coq_expr (mkProperty dt);
         GenericLib.debug_coq_expr checker;
+        (*run the generator called checker using QuickCheck.*)
+        (*failwith "OUch!";*)
+        let to_run = GenericLib.interp_open_coq_expr e evd (g_show (g_quickCheck (mkProperty dt))) in
+        (*failwith "Oucher!";*)
+        QuickChick.define_and_run to_run e evd;
+        
         Tacticals.tclIDTAC
       end
     | None -> failwith "Failed to Parse type"

--- a/plugin/tactic_quickchick.mlg.cppo
+++ b/plugin/tactic_quickchick.mlg.cppo
@@ -113,20 +113,39 @@ let quickchick_goal =
     | Some dt ->
       begin
         msg_debug (str (GenericLib.dep_type_to_string dt) ++ fnl ());
-        let decide prop = GenericLib.decToBool (GenericLib.g_dec prop) in
-        let checker = GenericLib.g_forAll GenericLib.g_arbitrary (GenericLib.gFun ["x"] (fun [x] -> 
-              GenericLib.g_forAll GenericLib.g_arbitrary (GenericLib.gFun ["y"] (fun [y] -> 
-                GenericLib.gIf (decide (GenericLib.gEq (GenericLib.gVar x) (GenericLib.gVar y))) 
-                              (GenericLib.g_checker (decide (GenericLib.gEq (GenericLib.gVar x) (GenericLib.gInt 0)))) 
-                               (GenericLib.g_checker GenericLib.gTT)
+        let open GenericLib in 
+        let decide prop = decOptToBool (g_decOpt prop (gInt 1000)) in
+        let rec mkProperty = function
+          | DProd ((var, _),body) -> 
+              g_forAll g_arbitrary (gFun [var_to_string var] (fun [_] ->
+                mkProperty body
+                )) 
+          | DArrow (x,y) -> gIf (decide (gType' [] x)) (mkProperty y) (g_checker gTT)
+          | p -> g_checker (decide (gType' [] p)) 
+              in
+          
+     (*     | DArrow (DTyCtr (tyctr, args), y) -> gIf (decide )
+          | DTyParam typaram -> gTyParam typaram
+          | DTyCtr (tyctr, args) -> gApp (gTyCtr tyctr) (List.map mkProperty args)
+          | DCtr (ctr, args) -> gApp (gCtr ctr) (List.map mkProperty args)
+          | DTyVar var -> gVar var
+          | DApp (f, args) -> gApp (mkProperty f) (List.map mkProperty args)
+          | DNot p -> *)
+(*Use decOpt, for every arrow, assume instacne exists and match on it *)
+        let checker = g_forAll g_arbitrary (gFun ["x"] (fun [x] -> 
+            g_forAll g_arbitrary (gFun ["y"] (fun [y] -> 
+              gIf (decide (gEq (gVar x) (gVar y))) 
+                  (g_checker (decide (gEq (gVar x) (gInt 0)))) 
+                  (g_checker gTT)
                ))        
              )) in
+        GenericLib.debug_coq_expr (mkProperty dt);
         GenericLib.debug_coq_expr checker;
         Tacticals.tclIDTAC
       end
     | None -> failwith "Failed to Parse type"
   end
-
+(*Create dependency graph, anything that lacks a dependency, print becuase we need it to *)
 (*    
     (* Make an evar with the goal as the type *)
     let evd, evar = Evarutil.new_pure_evar (Environ.named_context_val e) evd c in

--- a/plugin/tactic_quickchick.mlg.cppo
+++ b/plugin/tactic_quickchick.mlg.cppo
@@ -6,11 +6,10 @@ MAKE SURE TO EDIT THE .cppo SOURCE OF THIS FILE RATHER THAN THE GENERATED RESULT
 
 *)
 
-  open Stdarg
   open Ltac_plugin
   open Error
   open Pp
-  open QuickChick
+
 }
 
 DECLARE PLUGIN "coq-quickchick.plugin"
@@ -133,16 +132,8 @@ let quickchick_goal =
           | DApp (f, args) -> gApp (mkProperty f) (List.map mkProperty args)
           | DNot p -> *)
 (*Use decOpt, for every arrow, assume instacne exists and match on it *)
-        let checker = g_forAll g_arbitrary (gFun ["x"] (fun [x] -> 
-            g_forAll g_arbitrary (gFun ["y"] (fun [y] -> 
-              gIf (decide (gEq (gVar x) (gVar y))) 
-                  (g_checker (decide (gEq (gVar x) (gInt 0)))) 
-                  (g_checker gTT)
-               ))        
-             )) in
             
         GenericLib.debug_coq_expr (mkProperty dt);
-        GenericLib.debug_coq_expr checker;
         (*run the generator called checker using QuickCheck.*)
         (*failwith "OUch!";*)
         let to_run = GenericLib.interp_open_coq_expr e evd (g_show (g_quickCheck (mkProperty dt))) in

--- a/plugin/tactic_quickchick.mlg.cppo
+++ b/plugin/tactic_quickchick.mlg.cppo
@@ -276,7 +276,7 @@ let quickchick_goal =
 TACTIC EXTEND quickchick
   | ["quickchick"] -> { quickchick_goal }
 END
-(*
+
 TACTIC EXTEND merge_sound_core
   | ["merge_sound_core"] -> { merge_sound }
 END
@@ -284,4 +284,3 @@ END
 TACTIC EXTEND remember_induct
   | ["remember_induct" ident(h)] -> { remember_induct h }
 END
-*)

--- a/plugin/tactic_quickchick.mli
+++ b/plugin/tactic_quickchick.mli
@@ -1,0 +1,2 @@
+val remember_induct : Names.Id.t -> unit Proofview.tactic
+val merge_sound : unit Proofview.tactic

--- a/plugin/tactic_quickchick.mli
+++ b/plugin/tactic_quickchick.mli
@@ -1,2 +1,0 @@
-val remember_induct : Names.Id.t -> unit Proofview.tactic
-val merge_sound : unit Proofview.tactic

--- a/src/ExtractionQC.v.cppo
+++ b/src/ExtractionQC.v.cppo
@@ -131,7 +131,7 @@ Extract Constant print_extracted_coq_string =>
    let s = Bytes.create (List.length l) in
    let rec copy i = function
     | [] -> s
-    | c :: l -> s.[i] <- c; copy (i+1) l
+    | c :: l -> Bytes.set s i c; copy (i+1) l
    in Bytes.to_string (copy 0 l))".
 
 Axiom withTime : forall {A}, (unit -> A) -> AugmentedTime A.


### PR DESCRIPTION
Adds a tactic for Quickchecking the current proof goal in a naive fashion, using default generators for all variables and checking and filtering inputs against the hypotheses.