### PR TITLE
Defer evaluation of recursive generator calls when deriving generators

### DIFF
--- a/plugin/arbitrarySized.ml
+++ b/plugin/arbitrarySized.ml
@@ -39,10 +39,10 @@ let arbitrarySized_body (ty_ctr : ty_ctr) (ctrs : ctr_rep list) iargs =
     (fun (aux_arb, [size]) ->
       gMatch (gVar size)
         [(injectCtr "O", [],
-          fun _ -> oneof (List.map (create_for_branch tyParams aux_arb size) bases))
+          fun _ -> oneofThunked (List.map (create_for_branch tyParams aux_arb size) bases))
         ;(injectCtr "S", ["size'"],
-          fun [size'] -> frequency (List.map (fun (ctr,ty') ->
-                                        (Weightmap.lookup_weight ctr size',
+          fun [size'] -> frequencyThunked (List.map (fun (ctr,ty') ->
+                                        (Weightmap.lookup_weight (isBaseBranch ty') ctr size',
                                          create_for_branch tyParams aux_arb size' (ctr,ty'))) ctrs))
     ])
     (fun x -> gVar x)

--- a/plugin/arbitrarySizedST.ml
+++ b/plugin/arbitrarySizedST.ml
@@ -155,13 +155,13 @@ let arbitrarySizedST
          fun _ ->
            let opts = base_gens init_size (gVar size) full_gtyp gen_ctr dep_type ctrs rec_name
                         input_ranges init_umap init_tmap result in
-           uniform_backtracking (List.map fst opts))
+           uniform_backtracking (List.map thunkify (List.map fst opts)))
       ; (injectCtr "S", ["size'"],
          fun [size'] ->
            let opts = ind_gens init_size (gVar size') full_gtyp gen_ctr dep_type ctrs rec_name
                         input_ranges init_umap init_tmap result in
            let weights = List.map (fun ((c,_),(_,b)) -> Weightmap.lookup_weight b c size') (List.combine ctrs opts) in
-           backtracking (List.combine weights (List.map fst opts)))
+           backtracking (List.combine weights (List.map thunkify (List.map fst opts))))
       ]
   in
 

--- a/plugin/arbitrarySizedST.mli
+++ b/plugin/arbitrarySizedST.mli
@@ -48,7 +48,7 @@ val construct_generators :
   UnifyQC.range list ->
   UnifyQC.range UnifyQC.UM.t ->
   GenericLib.dep_type UnifyQC.UM.t ->
-  UnifyQC.Unknown.t -> GenericLib.coq_expr list                               
+  UnifyQC.Unknown.t -> (GenericLib.coq_expr * bool) list                               
 val base_gens :
   GenericLib.coq_expr ->
   GenericLib.coq_expr ->
@@ -60,7 +60,7 @@ val base_gens :
   UnifyQC.range list ->
   UnifyQC.range UnifyQC.UM.t ->
   GenericLib.dep_type UnifyQC.UM.t ->
-  UnifyQC.Unknown.t -> GenericLib.coq_expr list
+  UnifyQC.Unknown.t -> (GenericLib.coq_expr * bool) list
 val ind_gens :
   GenericLib.coq_expr ->
   GenericLib.coq_expr ->
@@ -72,7 +72,7 @@ val ind_gens :
   UnifyQC.range list ->
   UnifyQC.range UnifyQC.UM.t ->
   GenericLib.dep_type UnifyQC.UM.t ->
-  UnifyQC.Unknown.t -> GenericLib.coq_expr list  
+  UnifyQC.Unknown.t -> (GenericLib.coq_expr * bool) list  
 val arbitrarySizedST :
   GenericLib.ty_ctr ->
   GenericLib.ty_param list ->

--- a/plugin/genLib.ml
+++ b/plugin/genLib.ml
@@ -30,6 +30,8 @@ let enumChecker cg xn cf sz =
 let enumCheckerOpt cg xn cf sz = 
   gApp (gInject "enumeratingOpt") [cg; gFun [xn] (fun [x] -> cf x); sz]
 
+let thunkify g =
+  gApp (gInject "thunkGen") [gFun ["tt"] (fun [_] -> g)]
   
 let oneof l =
   match l with
@@ -37,11 +39,23 @@ let oneof l =
   | [c] -> c
   | c::cs -> gApp (gInject "oneOf_") [c; gList l]
 
+let oneofThunked l =
+  match l with
+  | [] -> failwith "oneof used with empty list"
+  | [c] -> c
+  | c::cs -> gApp (gInject "oneOf_") [c; gList (List.map thunkify l)]
+
 let frequency l =
   match l with
   | [] -> failwith "frequency used with empty list"
   | [(_,c)] -> c
   | (_,c)::cs -> gApp (gInject "freq_") [c; gList (List.map gPair l)]
+
+let frequencyThunked l =
+  match l with
+  | [] -> failwith "frequency used with empty list"
+  | [(_,c)] -> c
+  | (_,c)::cs -> gApp (gInject "freq_") [c; gList (List.map (fun (w,g) -> gPair (w, thunkify g)) l)]
 
 let enumerating l =
   gApp (gInject "enumerate") [gList l]

--- a/plugin/genLib.mli
+++ b/plugin/genLib.mli
@@ -27,7 +27,10 @@ val enumCheckerOpt :
   GenericLib.coq_expr -> GenericLib.coq_expr
   
 val oneof : GenericLib.coq_expr list -> GenericLib.coq_expr
+val oneofThunked : GenericLib.coq_expr list -> GenericLib.coq_expr
 val frequency :
+  (GenericLib.coq_expr * GenericLib.coq_expr) list -> GenericLib.coq_expr
+val frequencyThunked :
   (GenericLib.coq_expr * GenericLib.coq_expr) list -> GenericLib.coq_expr
 val backtracking :
   (GenericLib.coq_expr * GenericLib.coq_expr) list -> GenericLib.coq_expr

--- a/plugin/genLib.mli
+++ b/plugin/genLib.mli
@@ -25,7 +25,8 @@ val enumCheckerOpt :
   GenericLib.coq_expr ->
   string -> (GenericLib.var -> GenericLib.coq_expr) ->
   GenericLib.coq_expr -> GenericLib.coq_expr
-  
+
+val thunkify : GenericLib.coq_expr -> GenericLib.coq_expr
 val oneof : GenericLib.coq_expr list -> GenericLib.coq_expr
 val oneofThunked : GenericLib.coq_expr list -> GenericLib.coq_expr
 val frequency :

--- a/plugin/weightmap.mlg.cppo
+++ b/plugin/weightmap.mlg.cppo
@@ -80,11 +80,11 @@ let register_weights_object =
 
 let add_weights w = Lib.add_anonymous_leaf (register_weights_object w)
 #endif
-let lookup_weight ctr size_var = 
+let lookup_weight b ctr size_var = 
   try match CtrMap.find ctr !weight_env with
       | WNum n -> gInt n
       | WSize  -> gSucc (gVar (size_var))
-  with Not_found -> gInt 1
+  with Not_found -> if b then gInt 1 else gSucc (gVar (size_var))
 
 }
 

--- a/plugin/weightmap.mli
+++ b/plugin/weightmap.mli
@@ -9,4 +9,4 @@ val convert_constr_to_cw_pair :
   Constrexpr.constr_expr_r CAst.t -> GenericLib.constructor * weight_ast
 val register_weights_object :
   (GenericLib.constructor * weight_ast) list -> Libobject.obj
-val lookup_weight : CtrMap.key -> GenericLib.var -> GenericLib.coq_expr
+val lookup_weight : bool -> CtrMap.key -> GenericLib.var -> GenericLib.coq_expr


### PR DESCRIPTION
- Use `thunkGen` when deriving generators (both Arbitrary and ArbitraryST) to avoid eager evaluation causing exponential overheads.
- Introduce thunked variants of oneof and frequency in genLib.
- Correctly use `size` as the weight of recursive calls.