### PR TITLE
Add support for deriving simple instances for mutually inductive types.

### DIFF
--- a/plugin/arbitrarySized.ml
+++ b/plugin/arbitrarySized.ml
@@ -1,122 +1,209 @@
-open Pp
 open Util
 open GenericLib
 open GenLib
 open Error
-   
-(* Derivation of ArbitrarySized. Contains mostly code from derive.ml *)
+
+let arbitrarySized_decl (types : (ty_ctr * ctr_rep list) list) : (ty_ctr -> var list -> coq_expr) * ((var * (var * coq_expr) list * var * coq_expr * coq_expr) list) =
+  let impl_function_names : (ty_ctr * var) list =
+    List.map (fun (ty, _) -> 
+      let type_name = ty_ctr_to_string ty in
+      let function_name = fresh_name ("arbitrarySized_impl_" ^ type_name) in
+
+      (ty, function_name)
+    ) types in
+
+  let generate_arbitrarySized_function ((ty, ctors) : (ty_ctr * ctr_rep list)) : var * (var * coq_expr) list * var * coq_expr * coq_expr =
+    let function_name = List.assoc ty impl_function_names in
+
+    let arg = fresh_name "size" in
+    let arg_type = (gInject "Coq.Init.Datatypes.nat") in
+
+    (* G ty *)
+    let return_type = gApp (gInject "QuickChick.Generators.G") [gTyCtr ty] in
+
+    let find_ty_ctr = function
+    | TyCtr (ty_ctr', _) -> List.assoc_opt ty_ctr' impl_function_names
+    | _ -> None in
+
+    (* a base branch is a constructor that doesn't require our ty_ctr to be used *)
+    let is_base_branch ty =
+      fold_ty' (fun b ty' -> b && (None = (find_ty_ctr ty'))) true ty in
+    let base_branches =
+      List.filter (fun (_, ty) -> is_base_branch ty) ctors in
+
+    (* TODO: implement this back *)
+    (* let tyParams = [List.map gVar (list_drop_every 2 iargs)] in *)
+    let tyParams = [] in
+
+    let create_for_branch size (ctr, ty) =
+      let rec aux i acc ty : coq_expr =
+        match ty with
+        | Arrow (ty1, ty2) ->
+            bindGen
+              (match find_ty_ctr ty1 with
+                | Some name -> gApp (gVar name) [gVar size]
+                | None -> gInject "arbitrary")
+              (Printf.sprintf "p%d" i)
+              (fun pi -> aux (i+1) ((gVar pi) :: acc) ty2)
+        | _ -> returnGen (gApp ~explicit:true (gCtr ctr) (tyParams @ List.rev acc))
+      in aux 0 [] ty in
+    let body = gMatch (gVar arg) [
+      (
+        injectCtr "O", [],
+        fun _ -> oneofThunked (List.map (create_for_branch arg) base_branches)
+      );
+      (
+        injectCtr "S", ["size'"],
+        fun [size'] ->
+          frequencyThunked (List.map (fun (ctr, ty') ->
+            (Weightmap.lookup_weight (is_base_branch ty') ctr size', create_for_branch size' (ctr, ty'))
+          ) ctors)
+      )
+    ] in
+    debug_coq_expr body;
+
+    (function_name, [(arg, arg_type)], arg, return_type, body) in
+
+  let functions = List.map generate_arbitrarySized_function types in
+
+  (* returns {| arbitrarySized := arbitrarySized_impl_... |} *)
+  let instance_record ty_ctr ivars : coq_expr =
+    if List.length ivars > 0 then
+      (* This might be a regression compared to the version without support for mutual induction. *)
+      qcfail "Not implemented";
+
+    let impl_function_name = List.assoc ty_ctr impl_function_names in
+    gRecord [("arbitrarySized", gVar impl_function_name)] in
+  
+  (instance_record, functions)
 
 let rec replace v x = function
   | [] -> []
-  | y::ys -> if y = v then x::ys else y::(replace v x ys)
+  | y::ys -> if y = v
+      then x::ys
+      else y::(replace v x ys)
 
-let arbitrarySized_body (ty_ctr : ty_ctr) (ctrs : ctr_rep list) iargs = 
-  
-  let isCurrentTyCtr = function
-    | TyCtr (ty_ctr', _) -> ty_ctr = ty_ctr'
-    | _ -> false in
-  let isBaseBranch ty = fold_ty' (fun b ty' -> b && not (isCurrentTyCtr ty')) true ty in
+let shrink_decl (types : (ty_ctr * ctr_rep list) list) : (ty_ctr -> var list -> coq_expr) * ((var * (var * coq_expr) list * var * coq_expr * coq_expr) list) =
+  let impl_function_names : (ty_ctr * var) list =
+    List.map (fun (ty, _) -> 
+      let type_name = ty_ctr_to_string ty in
+      let function_name = fresh_name ("shrink_impl_" ^ type_name) in
 
-  let tyParams = List.map gVar (list_drop_every 2 iargs) in
+      (ty, function_name)
+    ) types in
 
-  (* Need reverse fold for this *)
-  let create_for_branch tyParams rec_name size (ctr, ty) =
-    let rec aux i acc ty : coq_expr =
-      match ty with
-      | Arrow (ty1, ty2) ->
-         bindGen (if isCurrentTyCtr ty1 then
-                     gApp (gVar rec_name) [gVar size]
-                  else gInject "arbitrary")
-           (Printf.sprintf "p%d" i)
-           (fun pi -> aux (i+1) ((gVar pi) :: acc) ty2)
-      | _ -> returnGen (gApp ~explicit:true (gCtr ctr) (tyParams @ List.rev acc))
-    in aux 0 [] ty in
-  
-  let bases = List.filter (fun (_, ty) -> isBaseBranch ty) ctrs in
+  let generate_show_function ((ty, ctors) : (ty_ctr * ctr_rep list)) : var * (var * coq_expr) list * var * coq_expr * coq_expr =
+    let function_name = List.assoc ty impl_function_names in
 
-  gRecFunInWithArgs
-    "arb_aux" [gArg ~assumName:(gInject "size") ()]
-    (fun (aux_arb, [size]) ->
-      gMatch (gVar size)
-        [(injectCtr "O", [],
-          fun _ -> oneofThunked (List.map (create_for_branch tyParams aux_arb size) bases))
-        ;(injectCtr "S", ["size'"],
-          fun [size'] -> frequencyThunked (List.map (fun (ctr,ty') ->
-                                        (Weightmap.lookup_weight (isBaseBranch ty') ctr size',
-                                         create_for_branch tyParams aux_arb size' (ctr,ty'))) ctrs))
-    ])
-    (fun x -> gVar x)
-  
-let arbitrarySized_decl ty_ctr ctrs iargs =
+    let arg = fresh_name "x" in
+    let arg_type = gTyCtr ty in
 
-  let arb_body = arbitrarySized_body ty_ctr ctrs iargs in
-  let arbitrary_decl = gFun ["s"] (fun [s] -> gApp arb_body [gVar s]) in
+    (* ty list *)
+    let return_type = gApp (gInject "Coq.Init.Datatypes.list") [gTyCtr ty] in
 
-  gRecord [("arbitrarySized", arbitrary_decl)]
-
-
-(** Shrinking Derivation *)
-let shrink_decl ty_ctr ctrs iargs =
-
-  let isCurrentTyCtr = function
-    | TyCtr (ty_ctr', _) -> ty_ctr = ty_ctr'
+    let is_current_ty_crt = function
+    | TyCtr (ty_ctr', _) -> ty = ty_ctr'
     | _ -> false in
 
-  let tyParams = List.map gVar (list_drop_every 2 iargs) in
+    let find_ty_ctr = function
+    | TyCtr (ty_ctr', _) -> List.assoc_opt ty_ctr' impl_function_names
+    | _ -> None in
 
-  let shrink_fun = 
-    let shrink_body x =
-      let create_branch aux_shrink (ctr, ty) =
-        (ctr, generate_names_from_type "p" ty,
-         fold_ty_vars (fun allParams v ty' ->
-             let liftNth = gFun ["shrunk"]
-                 (fun [shrunk] -> gApp ~explicit:true (gCtr ctr)
-                     (tyParams @ (replace (gVar v) (gVar shrunk) (List.map gVar allParams)))) in
-             lst_appends (if isCurrentTyCtr ty' then
-                            [ gList [gVar v] ; gApp (gInject "List.map") [liftNth; gApp (gVar aux_shrink) [gVar v]]]
-                          else
-                            [ gApp (gInject "List.map") [liftNth; gApp (gInject "shrink") [gVar v]]]))
-           lst_append list_nil ty) in
+    (* TODO: implement this back *)
+    (* let tyParams = [List.map gVar (list_drop_every 2 iargs)] in *)
+    let tyParams = [] in
 
-      let aux_shrink_body rec_fun x' = gMatch (gVar x') (List.map (create_branch rec_fun) ctrs) in
+    let create_branch (ctr, ty) = (
+      ctr,
+      generate_names_from_type "p" ty,
+      fold_ty_vars
+        (fun allParams v ty' ->
+          let liftNth =
+            gFun ["shrunk"]
+            (fun [shrunk] ->
+              gApp ~explicit:true (gCtr ctr) (tyParams @ (replace (gVar v) (gVar shrunk) (List.map gVar allParams))))
+          in
 
-      gRecFunIn "aux_shrink" ["x'"]
-        (fun (aux_shrink, [x']) -> aux_shrink_body aux_shrink x')
-        (fun aux_shrink -> gApp (gVar aux_shrink) [gVar x])
-    in
-    (* Create the function body by recursing on the structure of x *)
-    gFun ["x"] (fun [x] -> shrink_body x)
-  in
-  debug_coq_expr shrink_fun;
-  gRecord [("shrink", shrink_fun)]
+          lst_appends (match find_ty_ctr ty' with
+          | Some name ->
+              if is_current_ty_crt ty'
+                (* [[v], List.map liftNth (name v)] *)
+                then [ gList [gVar v] ; gApp (gInject "List.map") [liftNth; gApp (gVar name) [gVar v]] ]
+                (* [List.map liftNth (name v)] *)
+                else [ gApp (gInject "List.map") [liftNth; gApp (gVar name) [gVar v]] ]
+            (* [List.map liftNth (shrink v)] *)
+            | None -> [ gApp (gInject "List.map") [liftNth; gApp (gInject "shrink") [gVar v]] ]))
+        lst_append
+        list_nil ty
+    ) in
+    let body = gMatch (gVar arg) (List.map create_branch ctors) in
+    debug_coq_expr body;
 
-let show_decl ty_ctr ctrs _iargs =
-  msg_debug (str "Deriving Show Information:" ++ fnl ());
-  msg_debug (str ("Type constructor is: " ^ ty_ctr_to_string ty_ctr) ++ fnl ());
-  msg_debug (str (str_lst_to_string "\n" (List.map ctr_rep_to_string ctrs)) ++ fnl());
+    (function_name, [(arg, arg_type)], arg, return_type, body) in
 
-  let isCurrentTyCtr = function
-    | TyCtr (ty_ctr', _) -> ty_ctr = ty_ctr'
-    | _ -> false in
+  let functions = List.map generate_show_function types in
 
-  (* Create the function body by recursing on the structure of x *)
-  let show_body x =
-    
-    let branch aux (ctr,ty) =
-      
-      (ctr, generate_names_from_type "p" ty,
-       fun vs -> match vs with 
-                 | [] -> gStr (constructor_to_string ctr) 
-                 |_ -> str_append (gStr (constructor_to_string ctr ^ " "))
-                                  (fold_ty_vars (fun _ v ty' -> smart_paren (gApp (if isCurrentTyCtr ty' then gVar aux else gInject "show") [gVar v]))
-                                                (fun s1 s2 -> if s2 = emptyString then s1 else str_appends [s1; gStr " "; s2]) emptyString ty vs))
-    in
-    
-    gRecFunIn "aux" ["x'"]
-              (fun (aux, [x']) -> gMatch (gVar x') (List.map (branch aux) ctrs))
-              (fun aux -> gApp (gVar aux) [gVar x])
-  in
+  (* returns {| shrink := show_impl_... |} *)
+  let instance_record ty_ctr ivars : coq_expr =
+    if List.length ivars > 0 then
+      (* This might be a regression compared to the version without support for mutual induction. *)
+      qcfail "Not implemented";
+
+    let impl_function_name = List.assoc ty_ctr impl_function_names in
+    gRecord [("shrink", gVar impl_function_name)] in
   
-  let show_fun = gFun ["x"] (fun [x] -> show_body x) in
-  gRecord [("show", show_fun)]
-          
+  (instance_record, functions)
+
+let show_decl (types : (ty_ctr * ctr_rep list) list) : (ty_ctr -> var list -> coq_expr) * ((var * (var * coq_expr) list * var * coq_expr * coq_expr) list) =
+  let impl_function_names : (ty_ctr * var) list =
+    List.map (fun (ty, _) -> 
+      let type_name = ty_ctr_to_string ty in
+      let function_name = fresh_name ("show_impl_" ^ type_name) in
+
+      (ty, function_name)
+    ) types in
+
+  let generate_show_function ((ty, ctors) : (ty_ctr * ctr_rep list)) : var * (var * coq_expr) list * var * coq_expr * coq_expr =
+    let function_name = List.assoc ty impl_function_names in
+
+    let arg = fresh_name "x" in
+    let arg_type = gTyCtr ty in
+
+    let return_type = gInject "Coq.Strings.String.string" in
+
+    let find_ty_ctr = function
+    | TyCtr (ty_ctr', _) -> List.assoc_opt ty_ctr' impl_function_names
+    | _ -> None in
+
+    let branch (ctr, ty) = (
+        ctr,
+        generate_names_from_type "p" ty,
+        fun vs -> match vs with
+          | [] -> gStr (constructor_to_string ctr)
+          | _ -> str_append
+                  (gStr (constructor_to_string ctr ^ " "))
+                  (fold_ty_vars
+                    (fun _ v ty' ->
+                      smart_paren @@
+                      gApp (match find_ty_ctr ty' with
+                        | Some name -> gVar name
+                        | _ -> gInject "show"
+                      ) [gVar v])
+                    (fun s1 s2 ->
+                      if s2 = emptyString then s1
+                      else str_appends [s1; gStr " "; s2])
+                    emptyString ty vs)
+      ) in
+    (* match x with | Ctr p0 p1 ... pn -> "Ctr " ++ (...) ++ " " ++ (...) *)
+    let body = gMatch (gVar arg) (List.map branch ctors) in
+
+    (function_name, [(arg, arg_type)], arg, return_type, body) in
+
+  let functions = List.map generate_show_function types in
+
+  (* returns {| show := show_impl_... |} *)
+  let instance_record ty_ctr _ivars : coq_expr =
+    let impl_function_name = List.assoc ty_ctr impl_function_names in
+    gRecord [("show", gVar impl_function_name)] in
+  
+  (instance_record, functions)

--- a/plugin/arbitrarySized.mli
+++ b/plugin/arbitrarySized.mli
@@ -1,9 +1,9 @@
 val arbitrarySized_decl :
-  (GenericLib.ty_ctr * GenericLib.ctr_rep list) list ->
-  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * (GenericLib.var * GenericLib.coq_expr) list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
+  (GenericLib.ty_ctr * GenericLib.ty_param list * GenericLib.ctr_rep list) list ->
+  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * GenericLib.arg list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
 val shrink_decl :
-  (GenericLib.ty_ctr * GenericLib.ctr_rep list) list ->
-  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * (GenericLib.var * GenericLib.coq_expr) list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
+  (GenericLib.ty_ctr * GenericLib.ty_param list * GenericLib.ctr_rep list) list ->
+  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * GenericLib.arg list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
 val show_decl :
-  (GenericLib.ty_ctr * GenericLib.ctr_rep list) list ->
-  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * (GenericLib.var * GenericLib.coq_expr) list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
+  (GenericLib.ty_ctr * GenericLib.ty_param list * GenericLib.ctr_rep list) list ->
+  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * GenericLib.arg list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)

--- a/plugin/arbitrarySized.mli
+++ b/plugin/arbitrarySized.mli
@@ -1,13 +1,9 @@
-val replace : 'a -> 'a -> 'a list -> 'a list
-val arbitrarySized_body :
-  GenericLib.ty_ctr ->
-  GenericLib.ctr_rep list -> GenericLib.var list -> GenericLib.coq_expr
 val arbitrarySized_decl :
-  GenericLib.ty_ctr ->
-  GenericLib.ctr_rep list -> GenericLib.var list -> GenericLib.coq_expr
+  (GenericLib.ty_ctr * GenericLib.ctr_rep list) list ->
+  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * (GenericLib.var * GenericLib.coq_expr) list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
 val shrink_decl :
-  GenericLib.ty_ctr ->
-  (GenericLib.constructor * GenericLib.coq_type) list ->
-  GenericLib.var list -> GenericLib.coq_expr
+  (GenericLib.ty_ctr * GenericLib.ctr_rep list) list ->
+  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * (GenericLib.var * GenericLib.coq_expr) list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
 val show_decl :
-  GenericLib.ty_ctr -> GenericLib.ctr_rep list -> 'a -> GenericLib.coq_expr
+  (GenericLib.ty_ctr * GenericLib.ctr_rep list) list ->
+  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * (GenericLib.var * GenericLib.coq_expr) list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)

--- a/plugin/driver.mlg
+++ b/plugin/driver.mlg
@@ -12,11 +12,7 @@ type derivation = SimpleDer of SimplDriver.derivable list
                 | DepDer of DepDriver.derivable
 
 let simpl_dispatch ind classes name1 name2 =
-  let ind_name = match ind with
-    | { CAst.v = CRef (r, _); _ } -> string_of_qualid r
-    | _ -> failwith "Implement me for functions"
-  in
-  List.iter (fun cn -> SimplDriver.derive cn ind (SimplDriver.mk_instance_name cn ind_name) name1 name2) classes
+  List.iter (fun cn -> SimplDriver.derive cn ind name1 name2) classes
 
 let class_assoc_opts = [ ("GenSized"                 , SimpleDer [SimplDriver.GenSized])
                        ; ("EnumSized"                , SimpleDer [SimplDriver.EnumSized])                       

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -191,12 +191,16 @@ type ctr_rep = constructor * coq_type
 let ctr_rep_to_string (ctr, ct) = 
   Printf.sprintf "%s : %s" (constructor_to_string ctr) (coq_type_to_string ct)
 
-type dt_rep = ty_ctr * ty_param list * ctr_rep list
-let dt_rep_to_string (ty_ctr, ty_params, ctrs) = 
+type sdt_rep = ty_ctr * ty_param list * ctr_rep list
+type dt_rep = sdt_rep list
+let sdt_rep_to_string (ty_ctr, ty_params, ctrs) = 
   Printf.sprintf "%s %s :=\n%s" (ty_ctr_to_string ty_ctr) 
                                 (str_lst_to_string " "  (List.map ty_param_to_string ty_params))
                                 (str_lst_to_string "\n" (List.map ctr_rep_to_string  ctrs))
-                                 
+  
+let dt_rep_to_string r =
+  String.concat "\n" (List.map sdt_rep_to_string r)
+
 (* Supertype of coq_type handling potentially dependent stuff - TODO : merge *)
 type dep_type = 
   | DArrow of dep_type * dep_type (* Unnamed arrows *)
@@ -318,6 +322,13 @@ let rec arrowify terminal l =
   | [] -> terminal
   | x::xs -> Arrow (x, arrowify terminal xs)
 
+let qualid_to_mib (r : qualid) : mutual_inductive_body =
+  let (mind, _) = Nametab.global_inductive r in
+  let env = Global.env () in
+  let mib = Environ.lookup_mind mind env in
+
+  mib
+
 (* Receives number of type parameters and one_inductive_body.
    -> Possibly ty_param list as well? 
    Returns list of constructor representations 
@@ -361,11 +372,10 @@ let parse_constructors nparams param_names result_ty oib : ctr_rep list option =
         end 
       end
       else if isInd ty then begin
-        let ((mind, midx),_) = destInd ty in
-        let env = Global.env () in
-        let mib = Environ.lookup_mind mind env in
-        let id = mib.mind_packets.(midx).mind_typename in
-        Some (TyCtr (qualid_of_ident id, []))
+        let ((mind, i), _) = destInd ty in
+        let mib = qualid_to_mib @@ qualid_of_ident (Label.to_id (MutInd.label mind)) in
+        let oib = mib.mind_packets.(i) in
+        Some (TyCtr (qualid_of_ident @@ (oib.mind_typename), []))
       end
       else if isConst ty then begin
         let (c,_) = destConst ty in 
@@ -378,22 +388,27 @@ let parse_constructors nparams param_names result_ty oib : ctr_rep list option =
        Some (ctr_id, arrowify result_ty types)
   in
 
-  let cns = List.map qualid_of_ident (Array.to_list oib.mind_consnames) in
+  let (cns : qualid list) = List.map qualid_of_ident (Array.to_list oib.mind_consnames) in
   let map (ctx, t) = Term.it_mkProd_or_LetIn t ctx in
   let lc = Array.map_to_list map oib.mind_nf_lc in
   sequenceM parse_constructor (List.combine cns lc)
 
 (* Convert mutual_inductive_body to this representation, if possible *)
-let dt_rep_from_mib mib = 
-  if Array.length mib.mind_packets > 1 then begin
-    CErrors.user_err (str "Mutual inductive types not supported yet." ++ fnl())
-  end else 
-    let oib = mib.mind_packets.(0) in
-    let ty_ctr = oib.mind_typename in 
+let dt_rep_from_mib (mib : mutual_inductive_body) : dt_rep option = 
+  let dt_rep_from_oib (oib : one_inductive_body) : sdt_rep option =
+    let ty_ctr = oib.mind_typename in
     parse_type_params oib.mind_arity_ctxt >>= fun ty_params ->
     let result_ctr = TyCtr (qualid_of_ident ty_ctr, List.map (fun x -> TyParam x) ty_params) in
     parse_constructors mib.mind_nparams ty_params result_ctr oib >>= fun ctr_reps ->
     Some (qualid_of_ident ty_ctr, ty_params, ctr_reps)
+  in
+
+  Array.fold_left
+    (fun dt oib -> dt >>= fun (dt : sdt_rep list) ->
+      dt_rep_from_oib oib >>=
+      fun (sdt : sdt_rep) -> Some (sdt::dt))
+    (Some [])
+    mib.mind_packets
 
 let qualid_to_mib r =
   let env = Global.env () in
@@ -404,14 +419,20 @@ let qualid_to_mib r =
 
   mib
 
-    
-let coerce_reference_to_dt_rep c = 
+(* Legacy dt_rep_from_mib that fails on mutually inductive definitions *)
+let sdt_rep_from_mib (mib : mutual_inductive_body) : sdt_rep option =
+  if Array.length mib.mind_packets > 1 then
+    CErrors.user_err (str "Mutual inductive types not supported yet." ++ fnl())
+  else
+    dt_rep_from_mib mib >>= fun dt -> Some (List.hd dt)
+
+let coerce_reference_to_dt_rep (c : constr_expr) : dt_rep option = 
   let r = match c with
     | { CAst.v = CRef (r,_);_ } -> r
     | _ -> failwith "Not a reference"
   in
 
-  let mib = qualid_to_mib r in
+  let mib : mutual_inductive_body = qualid_to_mib r in
   
   dt_rep_from_mib mib
 
@@ -1297,7 +1318,38 @@ let define_new_inductive (ty_ctr, ty_params, ctrs, typ) =
   msg_debug (str "me_arity: " ++ Constr.debug_print oie.mind_entry_arity ++ fnl ());
   List.iteri (fun i c -> msg_debug (str "me_consname: " ++ int i ++ Constr.debug_print c ++ fnl ())) oie.mind_entry_lc;
   ignore (DeclareInd.declare_mutual_inductive_with_eliminations entry uentry impls) 
-  
+ 
+(* Declares a new Fixpoint function.
+
+  functions is a list of tuples that are, in this order:
+   - the function name
+   - the list of parameters, given as (parameter name, type) tuples
+   - the function argument to use to prove that the function terminates
+   - the return type
+   - the function body
+ *)
+let define_new_fixpoint (functions : (var * (var * coq_expr) list * var * coq_expr * coq_expr) list) =
+  let open Vernacexpr in
+  let open Glob_term in
+
+  let fixpoint_exprs : fixpoint_expr list = List.map
+    (fun (name, arguments, structural_wf_variable, return, body) ->
+      {
+        fname = CAst.make name;
+        univs = None;
+        rec_order = Some(CAst.make @@ CStructRec (CAst.make @@ structural_wf_variable));
+        binders = List.map (fun (name, ty) -> 
+          CLocalAssum ([CAst.make @@ Names.Name.mk_name @@ name], Default Explicit, ty)
+        ) arguments;
+        rtype = return;
+        body_def = Some body;
+        notations = []
+      }
+    ) functions in
+
+  ComFixpoint.do_fixpoint ~poly:false fixpoint_exprs
+
+
 (* List Utils. Probably should move to a util file instead *)
 let list_last l = List.nth l (List.length l - 1)
 let list_init l = List.rev (List.tl (List.rev l))

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -1347,7 +1347,8 @@ let define_new_fixpoint (functions : (var * arg list * var * coq_expr * coq_expr
 #if COQ_VERSION >= (8, 16, 0)
   ComFixpoint.do_fixpoint ~poly:false fixpoint_exprs
 #else
-  ComFixpoint.do_fixpoint ~scope:Locality.default_scope ~poly:false fixpoint_exprs
+  let default_scope = Locality.Global Locality.ImportDefaultBehavior in
+  ComFixpoint.do_fixpoint ~scope:default_scope ~poly:false fixpoint_exprs
 #endif
 
 

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -1323,14 +1323,13 @@ let define_new_inductive (ty_ctr, ty_params, ctrs, typ) =
 
   functions is a list of tuples that are, in this order:
    - the function name
-   - the list of parameters, given as (parameter name, type) tuples
+   - the list of arguments
    - the function argument to use to prove that the function terminates
    - the return type
    - the function body
  *)
-let define_new_fixpoint (functions : (var * (var * coq_expr) list * var * coq_expr * coq_expr) list) =
+let define_new_fixpoint (functions : (var * arg list * var * coq_expr * coq_expr) list) =
   let open Vernacexpr in
-  let open Glob_term in
 
   let fixpoint_exprs : fixpoint_expr list = List.map
     (fun (name, arguments, structural_wf_variable, return, body) ->
@@ -1338,9 +1337,7 @@ let define_new_fixpoint (functions : (var * (var * coq_expr) list * var * coq_ex
         fname = CAst.make name;
         univs = None;
         rec_order = Some(CAst.make @@ CStructRec (CAst.make @@ structural_wf_variable));
-        binders = List.map (fun (name, ty) -> 
-          CLocalAssum ([CAst.make @@ Names.Name.mk_name @@ name], Default Explicit, ty)
-        ) arguments;
+        binders = arguments;
         rtype = return;
         body_def = Some body;
         notations = []

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -1344,7 +1344,9 @@ let define_new_fixpoint (functions : (var * arg list * var * coq_expr * coq_expr
       }
     ) functions in
 
-#if COQ_VERSION >= (8, 16, 0)
+#if COQ_VERSION >= (8, 20, 0)
+  ignore (ComFixpoint.do_fixpoint ~poly:false fixpoint_exprs)
+#elif COQ_VERSION >= (8, 16, 0)
   ComFixpoint.do_fixpoint ~poly:false fixpoint_exprs
 #else
   let default_scope = Locality.Global Locality.ImportDefaultBehavior in

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -1347,7 +1347,11 @@ let define_new_fixpoint (functions : (var * (var * coq_expr) list * var * coq_ex
       }
     ) functions in
 
+#if COQ_VERSION >= (8, 16, 0)
   ComFixpoint.do_fixpoint ~poly:false fixpoint_exprs
+#else
+  ComFixpoint.do_fixpoint ~scope:Locality.default_scope ~poly:false fixpoint_exprs
+#endif
 
 
 (* List Utils. Probably should move to a util file instead *)

--- a/plugin/genericLib.ml.cppo
+++ b/plugin/genericLib.ml.cppo
@@ -1331,20 +1331,28 @@ let define_new_inductive (ty_ctr, ty_params, ctrs, typ) =
 let define_new_fixpoint (functions : (var * arg list * var * coq_expr * coq_expr) list) =
   let open Vernacexpr in
 
-  let fixpoint_exprs : fixpoint_expr list = List.map
+  let fixpoint_exprs = List.map
     (fun (name, arguments, structural_wf_variable, return, body) ->
       {
+#if COQ_VERSION < (9, 0, 0)
+        rec_order = Some (CAst.make @@ CStructRec (CAst.make @@ structural_wf_variable));
+#endif
         fname = CAst.make name;
         univs = None;
-        rec_order = Some(CAst.make @@ CStructRec (CAst.make @@ structural_wf_variable));
         binders = arguments;
         rtype = return;
         body_def = Some body;
         notations = []
       }
     ) functions in
-
-#if COQ_VERSION >= (8, 20, 0)
+#if COQ_VERSION >= (9, 0, 0)
+  let rec_orders = List.map
+    (fun (_, _, structural_wf_variable, _, _) ->
+      Some (CAst.make @@ CStructRec (CAst.make @@ structural_wf_variable)))
+    functions in
+  let kind = Decls.(IsDefinition Fixpoint) in
+  ignore (ComFixpoint.do_mutually_recursive ~poly:false ~kind ~program_mode:false (CFixRecOrder rec_orders, fixpoint_exprs))
+#elif COQ_VERSION >= (8, 20, 0)
   ignore (ComFixpoint.do_fixpoint ~poly:false fixpoint_exprs)
 #elif COQ_VERSION >= (8, 16, 0)
   ComFixpoint.do_fixpoint ~poly:false fixpoint_exprs

--- a/plugin/genericLib.mli
+++ b/plugin/genericLib.mli
@@ -282,7 +282,7 @@ val declare_class_instance
 val define_new_inductive : dep_dt -> unit
 
 val define_new_fixpoint :
-  (var * (var * coq_expr) list * var * coq_expr * coq_expr) list -> unit
+  (var * arg list * var * coq_expr * coq_expr) list -> unit
 
 (* List utils *)
 val list_last : 'a list -> 'a 

--- a/plugin/genericLib.mli
+++ b/plugin/genericLib.mli
@@ -77,7 +77,11 @@ val belongs_to_inductive : constructor -> bool
 type ctr_rep = constructor * coq_type 
 val ctr_rep_to_string : ctr_rep -> string
 
-type dt_rep = ty_ctr * ty_param list * ctr_rep list
+(* single dt_rep *)
+type sdt_rep = ty_ctr * ty_param list * ctr_rep list   
+type dt_rep = sdt_rep list
+ 
+val sdt_rep_to_string : sdt_rep -> string
 val dt_rep_to_string : dt_rep -> string
 
 (* Supertype of coq_type handling potentially dependent stuff - TODO : merge *)
@@ -125,6 +129,8 @@ val isSome : 'a option -> bool
 val cat_maybes : 'a option list -> 'a list
 val foldM : ('b -> 'a -> 'b option) -> 'b option -> 'a list -> 'b option
 val sequenceM : ('a -> 'b option) -> 'a list -> 'b list option
+(* legacy function which fails on mutually inductive definitions *)
+val sdt_rep_from_mib : mutual_inductive_body -> sdt_rep option
 
 val qualid_to_mib : Libnames.qualid -> mutual_inductive_body
 val dt_rep_from_mib : mutual_inductive_body -> dt_rep option
@@ -274,6 +280,9 @@ val declare_class_instance
   -> unit
 
 val define_new_inductive : dep_dt -> unit
+
+val define_new_fixpoint :
+  (var * (var * coq_expr) list * var * coq_expr * coq_expr) list -> unit
 
 (* List utils *)
 val list_last : 'a list -> 'a 

--- a/plugin/quickChick.mlg.cppo
+++ b/plugin/quickChick.mlg.cppo
@@ -422,7 +422,7 @@ let qcFuzz_main prop_def temp_dir execn prop_mlf prop_mlif warnings prop fuzzLoo
                                        ((match qualid_of_reference x with {CAst.v = q; _} -> q)))) !extract_manually;
                                        *)      
   List.iter (fun r ->
-      match GenericLib.dt_rep_from_mib (GenericLib.qualid_to_mib r) with
+      match GenericLib.sdt_rep_from_mib (GenericLib.qualid_to_mib r) with
       | Some (ty_ctr, ty_params, ctrs) -> begin
           (*          print_endline "Extracting inductive..."; *)
           let ty_ctr_name = qualify (String.uncapitalize_ascii (GenericLib.ty_ctr_to_string ty_ctr)) in

--- a/plugin/simplDriver.ml
+++ b/plugin/simplDriver.ml
@@ -50,17 +50,17 @@ let repeat_instance_name der tn =
   (prefix ^ strip_last tn)
 
 (* Generic derivation function *)
-let derive (cn : derivable) (c : constr_expr) (instance_name : string) (name1 : string) (name2 : string) =
-
-  let (ty_ctr, ty_params, ctrs) =
-    match coerce_reference_to_dt_rep c with
+let derive (cn : derivable) (c : constr_expr) (name1 : string) (name2 : string) =
+  let dt = match coerce_reference_to_dt_rep c with
     | Some dt -> dt
     | None -> failwith "Not supported type"  in
 
-  let coqTyCtr = gTyCtr ty_ctr in
-  let coqTyParams = List.map gTyParam ty_params in
+  let coqTyCtr = List.map (fun (ty_ctr, _, _) -> gTyCtr ty_ctr) dt in
+  let coqTyParams = List.map (fun (_, ty_params, _) -> List.map gTyParam ty_params) dt in
 
-  let full_dt = gApp ~explicit:true coqTyCtr coqTyParams in
+  let full_dt = List.map2
+    (fun coqTyCtr coqTyParams -> gApp ~explicit:true coqTyCtr coqTyParams)
+    coqTyCtr coqTyParams in
 
 (*
   let ind_name = match c with
@@ -109,20 +109,23 @@ let derive (cn : derivable) (c : constr_expr) (instance_name : string) (name1 : 
   in
 
   (* Generate typeclass constraints. For each type parameter "A" we need `{_ : <Class Name> A} *)
-  let instance_arguments =
-    let params =
-      (List.concat (List.map (fun tp ->
-                                ((gArg ~assumName:tp ~assumImplicit:true ()) ::
-                                (List.map (fun name -> gArg ~assumType:(gApp (gInject name) [tp]) ~assumGeneralized:true ()) param_class_names))
-                             ) coqTyParams))
+  let instance_arguments : (arg list) list = List.map (fun coqTyParams ->
+    let params = List.concat @@
+      List.map (fun tp -> (gArg ~assumName:tp ~assumImplicit:true ()) ::
+        (List.map (fun name -> gArg ~assumType:(gApp (gInject name) [tp]) ~assumGeneralized:true ()) param_class_names)
+      ) coqTyParams
     in
-    let args = (List.map (fun (name, typ) -> gArg ~assumName:name ~assumType:typ ()) extra_arguments) in
+
+    let args = List.map
+      (fun (name, typ) -> gArg ~assumName:name ~assumType:typ ())
+      extra_arguments in
+
     (* Add extra instance arguments *)
-    params @ args
+    params @ args) coqTyParams
   in
 
   (* The instance type *)
-  let instance_type iargs =
+  let instance_type full_dt iargs =
     (*
     match cn with
     | SizeMonotonic ->
@@ -135,15 +138,21 @@ let derive (cn : derivable) (c : constr_expr) (instance_name : string) (name1 : 
         [full_dt; hole; gInject ("arbitrarySized")]
     | _ -> *) gApp (gInject class_name) [full_dt]
   in
+
+  let inductive_types : (ty_ctr * ctr_rep list) list =
+    List.map (fun (ty_ctr, _, ctrs) -> (ty_ctr, ctrs)) dt
+  in
   (* Create the instance record. Only need to extend this for extra instances *)
-  let instance_record iargs =
+  let (instance_record, functions_to_mutually_define) :
+      (ty_ctr -> var list -> coq_expr)
+      * (var * (var * coq_expr) list * var * coq_expr * coq_expr) list =
     (* Copying code for Arbitrary, Sized from derive.ml *)
     match cn with
-    | Show -> show_decl ty_ctr ctrs iargs 
-    | Shrink -> shrink_decl ty_ctr ctrs iargs
-    | GenSized -> arbitrarySized_decl ty_ctr ctrs iargs
-    | EnumSized -> enumSized_decl ty_ctr ctrs iargs                
-    | Sized -> sized_decl ty_ctr ctrs
+    | Show -> show_decl inductive_types
+    | Shrink -> shrink_decl inductive_types
+    | GenSized -> arbitrarySized_decl inductive_types
+    | EnumSized -> enumSized_decl inductive_types
+    | Sized -> sized_decl inductive_types
              (*
     | CanonicalSized ->
       let ind_scheme =  gInject ((ty_ctr_to_string ty_ctr) ^ "_ind") in
@@ -161,7 +170,24 @@ let derive (cn : derivable) (c : constr_expr) (instance_name : string) (name1 : 
               *)
   in
 
-  (* msg_debug (str "Defined record" ++ fnl ()); *)
-  (* debug_coq_expr (instance_record []); *)
+  define_new_fixpoint functions_to_mutually_define;
 
-  declare_class_instance instance_arguments instance_name instance_type instance_record
+  let rec iter3 f l1 l2 l3 =
+    match (l1, l2, l3) with
+    | x1 :: l1, x2 :: l2, x3 :: l3 ->
+        f x1 x2 x3;
+        iter3 f l1 l2 l3
+    | [], [], [] -> ()
+    | _ -> raise (Invalid_argument "iter3")
+  in
+
+  iter3
+    (fun instance_arguments (ty_ctr, _, _) full_dt ->
+      let ind_name = ty_ctr_to_string ty_ctr in
+      let instance_name = mk_instance_name cn ind_name in
+
+      (* msg_debug (str "Defined record" ++ fnl ()); *)
+      (* debug_coq_expr (instance_record []); *)
+      declare_class_instance instance_arguments instance_name
+        (instance_type full_dt) (instance_record ty_ctr))
+    instance_arguments dt full_dt

--- a/plugin/simplDriver.mli
+++ b/plugin/simplDriver.mli
@@ -8,4 +8,4 @@ val derivable_to_string : derivable -> string
 val mk_instance_name : derivable -> string -> string
 val repeat_instance_name : derivable -> string -> string
 val derive :
-  derivable -> Constrexpr.constr_expr -> string -> string -> string -> unit
+  derivable -> Constrexpr.constr_expr -> string -> string -> unit

--- a/plugin/sized.mli
+++ b/plugin/sized.mli
@@ -4,8 +4,8 @@ val base_ctrs :
   GenericLib.ty_ctr ->
   ('a * GenericLib.coq_type) list -> ('a * GenericLib.coq_type) list
 val sized_decl :
-  (GenericLib.ty_ctr * GenericLib.ctr_rep list) list ->
-  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * (GenericLib.var * GenericLib.coq_expr) list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
+  (GenericLib.ty_ctr * GenericLib.ty_param list * GenericLib.ctr_rep list) list ->
+  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * GenericLib.arg list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
 val gen_args :
   GenericLib.coq_type ->
   GenericLib.ty_ctr -> int -> string list * string list

--- a/plugin/sized.mli
+++ b/plugin/sized.mli
@@ -4,8 +4,8 @@ val base_ctrs :
   GenericLib.ty_ctr ->
   ('a * GenericLib.coq_type) list -> ('a * GenericLib.coq_type) list
 val sized_decl :
-  GenericLib.ty_ctr ->
-  (GenericLib.constructor * GenericLib.coq_type) list -> GenericLib.coq_expr
+  (GenericLib.ty_ctr * GenericLib.ctr_rep list) list ->
+  (GenericLib.ty_ctr -> GenericLib.var list -> GenericLib.coq_expr) * ((GenericLib.var * (GenericLib.var * GenericLib.coq_expr) list * GenericLib.var * GenericLib.coq_expr * GenericLib.coq_expr) list)
 val gen_args :
   GenericLib.coq_type ->
   GenericLib.ty_ctr -> int -> string list * string list

--- a/src/EnumProofs.v
+++ b/src/EnumProofs.v
@@ -492,7 +492,7 @@ Ltac2 derive_enum_Correct (_ : unit) :=
   | [ |- @CorrectSized ?typ _ _ ?en ] =>  
     simpl_enumSized ();
     match! goal with
-    | [ |- @CorrectSized _ _ _ [eta ?en_simpl] ] =>
+    | [ |- @CorrectSized _ _ _ ?en_simpl ] =>
       (* get the enum body *)
       set (_aux_enum := ltac2:(exact $en_simpl));
       let hsize := Fresh.in_goal (id_of_string "Hsize") in

--- a/src/GenProofs.v
+++ b/src/GenProofs.v
@@ -437,7 +437,7 @@ Ltac2 derive_gen_Correct (_ : unit) :=
   | [ |- @CorrectSized ?typ _ _ ?en ] =>  
     simpl_enumSized ();
     match! goal with
-    | [ |- @CorrectSized _ _ _ [eta ?gen_simpl] ] =>
+    | [ |- @CorrectSized _ _ _ ?gen_simpl ] =>
       (* get the enum body *)
       set (_aux_gen := ltac2:(exact $gen_simpl));
       let hsize := Fresh.in_goal (id_of_string "Hsize") in

--- a/test/derive.v
+++ b/test/derive.v
@@ -1,0 +1,14 @@
+From QuickChick Require Import QuickChick Classes.
+
+Inductive a :=
+  | A1 : a
+  | A2 : b -> a
+with b :=
+  | B1 : b
+  | B2 : a -> b.
+
+Derive GenSized for a.
+Derive EnumSized for a.
+Derive Shrink for a.
+Derive Arbitrary for a.
+Derive Show for a.

--- a/test/dune
+++ b/test/dune
@@ -5,7 +5,7 @@
 (coq.theory
   (name QuickChick.Testing)
   (theories QuickChick)
-  (modules plugin))
+  (modules plugin derive))
 
 (coq.extraction
   (prelude mutation)


### PR DESCRIPTION
This pull request adds partial support for deriving instances of mutually inductive types. Only limited to simple typeclasses.

The supported typeclasses are:
- GenSized
- EnumSized
- Shrink
- Arbitrary
- Show
- Sized

To give a simple example, with this pull request, the following now works:
```coq
Require Import QuickChick.QuickChick.

Inductive a :=
  | A1 : a
  | A2 : b -> a
with b :=
  | B1 : b
  | B2 : a -> b.

Derive Show for a.

Eval compute in
  (show (A2 (B2 A1))).
(* "A2 (B2 A1)" *)
```