### PR TITLE
Move QuickChick's printing from info to notice

### DIFF
--- a/plugin/quickChick.mlg.cppo
+++ b/plugin/quickChick.mlg.cppo
@@ -243,7 +243,7 @@ let define_and_run c env evd =
     let (p_out, _, p_err) as process = Unix.open_process_full execn (Unix.environment ()) in
     let rec process_otl_aux () =
       let e = input_line p_out in
-      Feedback.msg_info (Pp.str e);
+      Feedback.msg_notice (Pp.str e);
       process_otl_aux() in
     try process_otl_aux ()
     with End_of_file ->
@@ -262,18 +262,18 @@ let define_and_run c env evd =
     let process_out () =
 (*      let rec process_err_aux () =
         let e = input_line p_err in
-        Feedback.msg_info (Pp.str e);
+        Feedback.msg_notice (Pp.str e);
         process_err_aux() in
 *)        
       let rec process_otl_aux () =
         let e = input_line p_out in
-        Feedback.msg_info (Pp.str e);
+        Feedback.msg_notice (Pp.str e);
         process_otl_aux() in
       try process_otl_aux ()
       with End_of_file ->
              let stop = Unix.gettimeofday () in
              let timeElapsed = stop -. start in
-             Feedback.msg_info (Pp.str (Printf.sprintf "Time Elapsed: %fs\n" timeElapsed));
+             Feedback.msg_notice (Pp.str (Printf.sprintf "Time Elapsed: %fs\n" timeElapsed));
             (* try process_err_aux ()
             with End_of_file ->  *)
               let err_msg = read_all p_err in
@@ -335,7 +335,7 @@ let run f args =
   begin match last args with
   | Some qc_text ->
     let msg = "QuickChecking " ^ Pp.string_of_ppcmds (Ppconstr.pr_constr_expr env evd qc_text) in
-    Feedback.msg_info (Pp.str msg)
+    Feedback.msg_notice (Pp.str msg)
   | None -> failwith "run called with no arguments"
   end;
   let args = List.map (fun x -> (x,None)) args in


### PR DESCRIPTION
As noted in #267, VSCoq would completely ignore QuickChick's messages (and other similar information at "Info" level), hiding them in a hard-to-find buffer. This moves all printing to use `Feedback.msg_notice` instead of `Feedback.msg_info`, which sets QuickChick's messages at the same level as `Print foo` or `Show foo` commands.