### PR TITLE
Re-enable warning 9 (Missing fields in a record pattern)

### DIFF
--- a/plugin/dune
+++ b/plugin/dune
@@ -1,7 +1,7 @@
 (library
  (name quickchick_plugin)
  (public_name coq-quickchick.plugin)
- (flags :standard -rectypes -warn-error -3 -w -8-9-27+40)
+ (flags :standard -rectypes -warn-error -3 -w -8-27+40)
  (modules :standard \ genSTCorrect genSizedSTMonotonic genSizedSTSizeMonotonic)
  (libraries unix str
   (select void_for_linking-plugin-extraction from


### PR DESCRIPTION
Hoping it somehow went away