### PR TITLE
Adapt to Coq PR #19404: an algebra of types for the instances of notation variables

### DIFF
--- a/plugin/driver.mlg
+++ b/plugin/driver.mlg
@@ -44,8 +44,9 @@ let dispatch cn ind name1 name2 =
     | {CAst.v = CRef (r, _) ; _} -> string_of_qualid r
     | _ -> failwith "Usage: Derive <class_name> for <inductive_name> OR  Derive (<class_name>, ... , <class_name>) for <inductive_name>" in
   let ss = match cn.CAst.v with
-     | CNotation (_, _, ([a],[b],_,_)) ->
+     | CNotation (_, _, [NtnTypeArg (NtnTypeArgConstr a); NtnTypeArgList b]) ->
          let c = convert_reference_to_string a in
+         let b = List.map (function (NtnTypeArg (NtnTypeArgConstr b)) -> b | _ -> failwith "Usage: Derive <class_name> for <inductive_name> OR  Derive (<class_name>, ... , <class_name>) for <inductive_name>") b in
          let cs = List.map convert_reference_to_string b in
          c :: cs
      | _ -> [convert_reference_to_string cn]

--- a/plugin/quickChick.mlg.cppo
+++ b/plugin/quickChick.mlg.cppo
@@ -369,8 +369,10 @@ let add_manual_extract cs =
     | _ -> failwith "Usage: Extract Manually failed." in
   let refs : qualid list =
     match cs with
-    | { CAst.v = CNotation (_,_,([a],[b],_,_)) ; _ } -> begin
+    | { CAst.v = CNotation (_, _, [NtnTypeArg (NtnTypeArgConstr a); NtnTypeArgList b]) ; _ }
+        when List.for_all (function (NtnTypeArg (NtnTypeArgConstr _)) -> true | _ -> false) b -> begin
          let q = convert_reference_to_qualid a in
+         let b = List.map (function (NtnTypeArg (NtnTypeArgConstr b)) -> b | _ -> assert false) b in
          let qs = List.map convert_reference_to_qualid b in
          q :: qs
        end

--- a/plugin/weightmap.mlg.cppo
+++ b/plugin/weightmap.mlg.cppo
@@ -53,7 +53,7 @@ let convert_constr_to_weight c =
 
 let convert_constr_to_cw_pair c : (constructor * weight_ast) = 
   match c.CAst.v with
-  | CNotation (_, _, ([a],[[b]],_,_)) ->
+  | CNotation (_, _, [NtnTypeArg (NtnTypeArgConstr a); NtnTypeArgList [NtnTypeArg (NtnTypeArgConstr b)]]) ->
       let ctr = 
         match a with 
         | { CAst.v = CRef (r, _); _ } -> injectCtr (string_of_qualid r)
@@ -93,8 +93,10 @@ VERNAC COMMAND EXTEND QuickChickWeights CLASSIFIED AS SIDEFF
      {
        let weight_assocs = 
          match c.CAst.v with
-         | CNotation (_, _, ([a],[b],_,_)) ->
+         | CNotation (_, _, [NtnTypeArg (NtnTypeArgConstr a); NtnTypeArgList b])
+           when List.for_all (function (NtnTypeArg (NtnTypeArgConstr _)) -> true | _ -> false) b ->
              let c = convert_constr_to_cw_pair a in
+             let b = List.map (function (NtnTypeArg (NtnTypeArgConstr b)) -> b | _ -> assert false) b in
              let cs = List.map convert_constr_to_cw_pair b in
              c :: cs
          | _ -> failwith "QC: Expected list of constructor -> weights"


### PR DESCRIPTION
This PR is in preparation of coq/coq#19404 which introduces an algebra of types for the instances of notation variables.

The code is a bit more complex due to the typing annotation, I'm sorry.

Otherwise, to be merged synchronously.