### PR TITLE
Change Derive vernacular identifier

### DIFF
--- a/plugin/driver.mlg
+++ b/plugin/driver.mlg
@@ -92,7 +92,7 @@ VERNAC COMMAND EXTEND MergeTest CLASSIFIED AS SIDEFF
     { merge_test ind1 }
 END
 
-VERNAC COMMAND EXTEND Derive CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND QuickChickDerive CLASSIFIED AS SIDEFF
    | ["Derive" constr(class_name) "for" constr(inductive)] ->
      { dispatch class_name inductive "" "" }
    | ["Derive" constr(class_name) "for" constr(inductive) "using" ident(genInst)] ->


### PR DESCRIPTION
QuickChick and Equations cannot be required/imported in the same file in older versions of Coq (<= 8.18) since they both define a `Derive` vernacular using the same id "Derive".
This PR changes it to "QuickChickDerive" to avoid clashes with other plugins defining a `Derive` vernacular.

Related to https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Anomaly.3A.20bad.20vernac.20extend